### PR TITLE
Mylin/#8 improve match spectral

### DIFF
--- a/src/test/MATCH_SPECTRAL.test.ts
+++ b/src/test/MATCH_SPECTRAL.test.ts
@@ -2,6 +2,7 @@ import { CARTA } from "carta-protobuf";
 import { checkConnection, Stream} from './myClient';
 import { MessageController } from "./MessageController";
 import config from "./config.json";
+import { ProtobufProcessing } from "./Processed";
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
@@ -22,7 +23,7 @@ interface AssertItem {
 }
 
 let assertItem: AssertItem = {
-    precisionDigits: 4,
+    precisionDigits: 8,
     openFile: [
         {
             directory: testSubdirectory,
@@ -245,7 +246,13 @@ describe("MATCH_SPECTRAL: Test region spectral profile with spatially and spectr
             });
     
             test(`Assert the first profile equal to the last profile`, () => {
-                expect(SpectralProfileData.find(data => data.fileId == assertItem.openFile[0].fileId).profiles).toEqual(SpectralProfileData.find(data => data.fileId == assertItem.openFile[3].fileId).profiles);
+                let p0 = SpectralProfileData.find(data => data.fileId == assertItem.openFile[0].fileId).profiles;
+                let v0 = ProtobufProcessing.ProcessSpectralProfile(p0[0],1);
+                let p3 = SpectralProfileData.find(data => data.fileId == assertItem.openFile[3].fileId).profiles;
+                let v3 = ProtobufProcessing.ProcessSpectralProfile(p3[0],1);
+                for (let index = 0; index < v3.values.length; index++) {
+                    expect(v3.values[index]).toEqual(v0.values[index]);
+                }
             });
         });
 

--- a/src/test/Processed.ts
+++ b/src/test/Processed.ts
@@ -1,0 +1,173 @@
+// import * as CARTACompute from "carta_computation";
+import {CARTA} from "carta-protobuf";
+
+export type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+export type ColumnArray = Array<string> | Array<boolean> | Array<number>;
+
+export interface ProcessedSpatialProfile extends CARTA.ISpatialProfile {
+    values: Float32Array;
+}
+
+export interface ProcessedSpectralProfile extends CARTA.ISpectralProfile {
+    values: Float32Array | Float64Array;
+    progress: number;
+}
+
+export interface ProcessedContourData {
+    fileId: number;
+    imageBounds?: CARTA.IImageBounds;
+    channel: number;
+    stokes: number;
+    progress: number;
+    contourSets: ProcessedContourSet[];
+}
+
+export interface ProcessedContourSet {
+    level: number;
+    indexOffsets: Int32Array;
+    coordinates: Float32Array;
+}
+
+export interface ProcessedColumnData {
+    dataType: CARTA.ColumnType;
+    data: ColumnArray | TypedArray;
+}
+
+export class ProtobufProcessing {
+    static ProcessSpatialProfile(profile: CARTA.ISpatialProfile): ProcessedSpatialProfile {
+        if (profile.rawValuesFp32 && profile.rawValuesFp32.length && profile.rawValuesFp32.length % 4 === 0) {
+            return {
+                coordinate: profile.coordinate,
+                start: profile.start,
+                end: profile.end,
+                mip: profile.mip,
+                values: new Float32Array(profile.rawValuesFp32.slice().buffer),
+                lineAxis: profile.lineAxis
+            };
+        }
+
+        return {
+            coordinate: profile.coordinate,
+            start: profile.start,
+            end: profile.end,
+            mip: profile.mip,
+            values: null,
+            lineAxis: profile.lineAxis
+        };
+    }
+
+    static ProcessSpectralProfile(profile: CARTA.ISpectralProfile, progress: number): ProcessedSpectralProfile {
+        if (profile.rawValuesFp64 && profile.rawValuesFp64.length && profile.rawValuesFp64.length % 8 === 0) {
+            return {
+                coordinate: profile.coordinate,
+                statsType: profile.statsType,
+                values: new Float64Array(profile.rawValuesFp64.slice().buffer),
+                progress
+            };
+        } else if (profile.rawValuesFp32 && profile.rawValuesFp32.length && profile.rawValuesFp32.length % 4 === 0) {
+            return {
+                coordinate: profile.coordinate,
+                statsType: profile.statsType,
+                values: new Float32Array(profile.rawValuesFp32.slice().buffer),
+                progress
+            };
+        }
+
+        return {
+            coordinate: profile.coordinate,
+            statsType: profile.statsType,
+            values: null,
+            progress: 0
+        };
+    }
+
+    static ProcessContourSet(contourSet: CARTA.IContourSet): ProcessedContourSet {
+        const isCompressed = contourSet.decimationFactor >= 1;
+
+        let floatCoordinates: Float32Array;
+        if (isCompressed) {
+            // Decode raw coordinates from Zstd-compressed binary to a float array
+            floatCoordinates = CARTACompute.Decode(contourSet.rawCoordinates, contourSet.uncompressedCoordinatesSize, contourSet.decimationFactor);
+        } else {
+            const u8Copy = contourSet.rawCoordinates.slice();
+            floatCoordinates = new Float32Array(u8Copy.buffer);
+        }
+        // generate indices
+        const indexOffsets = new Int32Array(contourSet.rawStartIndices.buffer.slice(contourSet.rawStartIndices.byteOffset, contourSet.rawStartIndices.byteOffset + contourSet.rawStartIndices.byteLength));
+
+        return {
+            level: contourSet.level,
+            indexOffsets,
+            coordinates: floatCoordinates
+        };
+    }
+
+    static ProcessContourData(contourData: CARTA.IContourImageData): ProcessedContourData {
+        return {
+            fileId: contourData.fileId,
+            channel: contourData.channel,
+            stokes: contourData.stokes,
+            imageBounds: contourData.imageBounds,
+            progress: contourData.progress,
+            contourSets: contourData.contourSets ? contourData.contourSets.map(contourSet => this.ProcessContourSet(contourSet)) : null
+        };
+    }
+
+    static GetProcessedData(column: CARTA.IColumnData): ProcessedColumnData {
+        let data: TypedArray;
+        switch (column.dataType) {
+            case CARTA.ColumnType.Uint8:
+                data = new Uint8Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Int8:
+                data = new Int8Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Uint16:
+                data = new Uint16Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Int16:
+                data = new Int16Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Uint32:
+                data = new Uint32Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Int32:
+                data = new Int32Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Float:
+                data = new Float32Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Double:
+                data = new Float64Array(column.binaryData.slice().buffer);
+                break;
+            case CARTA.ColumnType.Int64:
+                data = CARTACompute.ConvertInt64Array(column.binaryData, true);
+                break;
+            case CARTA.ColumnType.Uint64:
+                data = CARTACompute.ConvertInt64Array(column.binaryData, false);
+                break;
+            case CARTA.ColumnType.Bool:
+                const array = new Uint8Array(column.binaryData.slice().buffer);
+                const boolData = new Array<boolean>(array.length);
+                for (let i = boolData.length - 1; i >= 0; i--) {
+                    boolData[i] = array[i] !== 0;
+                }
+                return {dataType: column.dataType, data: boolData};
+            case CARTA.ColumnType.String:
+                return {dataType: column.dataType, data: column.stringData};
+            default:
+                return {dataType: CARTA.ColumnType.UnsupportedType, data: []};
+        }
+        return {dataType: column.dataType, data: data};
+    }
+
+    static ProcessCatalogData(catalogData: {[k: string]: CARTA.IColumnData}): Map<number, ProcessedColumnData> {
+        const dataMap = new Map<number, ProcessedColumnData>();
+        const originalMap = new Map(Object.entries(catalogData));
+        originalMap.forEach((column, i) => {
+            dataMap.set(parseInt(i), ProtobufProcessing.GetProcessedData(column));
+        });
+
+        return dataMap;
+    }
+}


### PR DESCRIPTION
Try to fix #8.
I modified MATCH_SPECTRAL.test.ts to match the spectral profile value rather than comparing the rawValuesFp64 itself. 
Let's see whether it can reduce the failure on the servers.

I only test MacOS11 with current carta-backend dev branch, once it passes to other platforms, please feel free to merge to the ICD-RxJS dev branch. Thanks : D