### PR TITLE
add checking all spectralProfileData progress = 1

### DIFF
--- a/src/test/MATCH_SPECTRAL.test.ts
+++ b/src/test/MATCH_SPECTRAL.test.ts
@@ -230,13 +230,22 @@ describe("MATCH_SPECTRAL: Test region spectral profile with spatially and spectr
         });
 
         describe(`Test acquire all spectral profiles after enlarge region`, () => {
-            let SpectralProfileData: CARTA.SpectralProfileData[] = [];
+            let SpectralProfileData: any[] = [];
             test(`Should rotate region 1`, async () => {
                 await msgController.setRegion(assertItem.setRegion[1].fileId, assertItem.setRegion[1].regionId, assertItem.setRegion[1].regionInfo);
                 for (const [index, spectralRequirement] of assertItem.setSpectralRequirements.entries()) {
-                    let SpectralProfileDataResponse = await Stream(CARTA.SpectralProfileData);
-                    SpectralProfileData.push(SpectralProfileDataResponse[0]);                    
-                }
+                    let SpectralProfileDataStreamPromise = new Promise((resolve) => {
+                        msgController.spectralProfileStream.subscribe({
+                            next: (data) => {
+                                if (data.progress === 1) {
+                                    resolve(data)
+                                }
+                            }
+                        })
+                    })
+                    let SpectralProfileDataResponse = await SpectralProfileDataStreamPromise;
+                    SpectralProfileData.push(SpectralProfileDataResponse);             
+                };
             }, profileTimeout * 3);
     
             test(`Assert all region_id`, () => {


### PR DESCRIPTION
Fixed #8 
As KS mentioned about the progress = 1 problem yesterday.
I used to think the region is small (when I implement this test), all spectralProfileData can be returned with 1 ICD message. However now I am thinking it really depends on how busy the server is. we cannot rule out the possibility that the server is busy and the spectralProfileData returned with >1 ICD messages. 
So I modify the test code again, only retrieve the spectralProfileData with its progress === 1.

Sorry for multi-solutions with this problem and you have to review and test it again ><
please feel free to merge to dev branch if you think it can pass with different platforms.