### PR TITLE
Mylin/#6 annotation region

### DIFF
--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -94,8 +94,15 @@ let assertItem: AssertItem = {
                 regionType: CARTA.RegionType.LINE,
             },
             '8': {
+                controlPoints: [{ x: 320, y: 400 }, {x: 370, y: 450}],
+                regionType: CARTA.RegionType.ANNVECTOR,
+            },
+            '9': {
+                controlPoints: [{ x: 320, y: 400 }, {}],
+                regionType: CARTA.RegionType.ANNTEXT,
+            },
+            '10': {
                 controlPoints: [{ x: 320, y: 300 }],
-                regionType: CARTA.RegionType.POINT,
             },
         },
         regionStyles: {
@@ -107,6 +114,8 @@ let assertItem: AssertItem = {
             '6': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
             '7': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
             '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
+            '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
         },
     },
     exportRegion:
@@ -118,14 +127,16 @@ let assertItem: AssertItem = {
                 fileId: 0,
                 type: CARTA.FileType.CRTF,
                 regionStyles: {
-                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
+                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
+                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
+                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '9': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: { textLabel0: "CARTA REGION TEST", font: "Helvetica", fontSize: 20, fontStyle: "Normal", textPosition: 0} },
+                    '10': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
                 },
             },
             {
@@ -135,14 +146,16 @@ let assertItem: AssertItem = {
                 fileId: 0,
                 type: CARTA.FileType.CRTF,
                 regionStyles: {
-                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
+                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
+                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
+                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {}},
+                    '9': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: { textLabel0: "CARTA REGION TEST", font: "Helvetica", fontSize: 20, fontStyle: "Normal", textPosition: 0} },
+                    '10': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: {} },
                 }
             },
         ],
@@ -178,18 +191,18 @@ let assertItem: AssertItem = {
         [
             {
                 success: true,
-                lengthOfRegions: 8,
+                lengthOfRegions: 10,
                 assertRegionId: {
-                    index: 7,
-                    id: 16,
+                    index: 10,
+                    id: 20,
                 },
             },
             {
                 success: true,
-                lengthOfRegions: 8,
+                lengthOfRegions: 10,
                 assertRegionId: {
-                    index: 7,
-                    id: 24,
+                    index: 10,
+                    id: 30,
                 },
             },
         ],
@@ -245,9 +258,12 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                 Object.keys(assertItem.importRegionAck.regions).map((region, index) => {
                     test(`IMPORT_REGION_ACK.region[${index}] = "Id:${region}, Type:${CARTA.RegionType[assertItem.importRegionAck.regions[region].regionType]}"`, () => {
                         expect(importRegionAckProperties[index]).toEqual(String(region));
-                        expect(importRegionAck.regions[importRegionAckProperties[index]].regionType).toEqual(assertItem.importRegionAck.regions[region].regionType);
-                        if (assertItem.importRegionAck.regions[region].rotation)
+                        if (assertItem.importRegionAck.regions[region].regionType) {
+                            expect(importRegionAck.regions[importRegionAckProperties[index]].regionType).toEqual(assertItem.importRegionAck.regions[region].regionType);
+                        }
+                        if (assertItem.importRegionAck.regions[region].rotation) {
                             expect(importRegionAck.regions[importRegionAckProperties[index]].rotation).toEqual(assertItem.importRegionAck.regions[region].rotation);
+                        }
                         expect(importRegionAck.regions[importRegionAckProperties[index]].controlPoints).toEqual(assertItem.importRegionAck.regions[region].controlPoints);
                     });
                 });
@@ -265,6 +281,8 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                         regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
                         regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
                         regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(9, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(10, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
                         assertItem.exportRegion[idxRegion].directory = basepath + "/" + assertItem.exportRegion[idxRegion].directory
                         exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
@@ -286,8 +304,8 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                     let importRegionAckProperties: any;
                     test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                         assertItem.importRegion2[idxRegion].directory = basepath + "/" + assertItem.importRegion2[idxRegion].directory;
-                        importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
-                        
+                        importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId);
+
                         importRegionAckProperties = Object.keys(importRegionAck.regions);
                         if (importRegionAck.message != '') {
                             console.warn(importRegionAck.message);

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -6,7 +6,7 @@ import config from "./config.json";
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let regionSubdirectory = config.path.region;
-let saveSubdirectory = config.path.save;
+let saveSubdirectory = config.path.save_local;
 let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 let exportTimeout = config.timeout.export;
@@ -284,7 +284,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                         regionStyle.set(9, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: { textLabel0: "CARTA REGION TEST", font: "Helvetica", fontSize: 20, fontStyle: "Normal", textPosition: 0} });
                         regionStyle.set(10, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
-                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + assertItem.exportRegion[idxRegion].directory
+                        assertItem.exportRegion[idxRegion].directory = assertItem.exportRegion[idxRegion].directory
                         exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
                     }, exportTimeout);
     
@@ -303,7 +303,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                     let importRegionAck: any;
                     let importRegionAckProperties: any;
                     test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        assertItem.importRegion2[idxRegion].directory = basepath + "/" + assertItem.importRegion2[idxRegion].directory;
+                        assertItem.importRegion2[idxRegion].directory = assertItem.importRegion2[idxRegion].directory;
                         importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId);
 
                         importRegionAckProperties = Object.keys(importRegionAck.regions);

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -281,7 +281,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                         regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
                         regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
                         regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(9, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(9, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: { textLabel0: "CARTA REGION TEST", font: "Helvetica", fontSize: 20, fontStyle: "Normal", textPosition: 0} });
                         regionStyle.set(10, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
                         assertItem.exportRegion[idxRegion].directory = basepath + "/" + assertItem.exportRegion[idxRegion].directory

--- a/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
@@ -51,8 +51,8 @@ let assertItem: AssertItem = {
         ],
     importRegionAck:
         [
-            { message: "Region import failed: Not a valid DS9 region file" },
-            { message: "Region import failed: Not a valid DS9 region file" },
+            { message: "Invalid DS9 region syntax:" },
+            { message: "Invalid DS9 region syntax:" },
         ],
 };
 

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -65,33 +65,45 @@ let assertItem: AssertItem = {
         success: true,
         regions: {
             '1': {
-                controlPoints: [{ x: 319, y: 399 }, { x: 40, y: 100 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 40, y: 100 }],
                 regionType: CARTA.RegionType.RECTANGLE,
             },
             '2': {
-                controlPoints: [{ x: 319, y: 399 }, { x: 100, y: 40 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 40 }],
                 regionType: CARTA.RegionType.RECTANGLE,
             },
             '3': {
-                controlPoints: [{ x: 319, y: 399 }, { x: 200, y: 40 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 40 }],
                 rotation: 45,
                 regionType: CARTA.RegionType.RECTANGLE,
             },
             '4': {
-                controlPoints: [{ x: 319, y: 399 }, { x: 319, y: 599 }, { x: 399, y: 399 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 600 }, { x: 400, y: 400 }],
                 regionType: CARTA.RegionType.POLYGON,
             },
             '5': {
-                controlPoints: [{ x: 319, y: 399 }, { x: 200, y: 200 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 200 }],
                 regionType: CARTA.RegionType.ELLIPSE,
             },
             '6': {
-                controlPoints: [{ x: 319, y: 399 }, { x: 100, y: 20 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 20 }],
                 regionType: CARTA.RegionType.ELLIPSE,
                 rotation: 45,
             },
             '7': {
-                controlPoints: [{ x: 319, y: 299 }],
+                controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 300}],
+                regionType: CARTA.RegionType.LINE,
+            },
+            '8': {
+                controlPoints: [{ x: 320, y: 400 }, {x: 369.99951171875, y: 449.99951171875}],
+                regionType: CARTA.RegionType.ANNVECTOR,
+            },
+            '9': {
+                controlPoints: [{ x: 320, y: 400 }, {}],
+                regionType: CARTA.RegionType.ANNTEXT,
+            },
+            '10': {
+                controlPoints: [{ x: 320, y: 300 }],
                 regionType: CARTA.RegionType.POINT,
             },
         },
@@ -103,6 +115,9 @@ let assertItem: AssertItem = {
             '5': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
             '6': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
             '7': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
         },
     },
     exportRegion:
@@ -246,60 +261,60 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                 });
             });
 
-            assertItem.exportRegionAck.map((exRegion, idxRegion) => {
-                describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
-                    let exportRegionAck: any;
-                    test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(2, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(3, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(4, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(5, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-                        regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            // assertItem.exportRegionAck.map((exRegion, idxRegion) => {
+            //     describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
+            //         let exportRegionAck: any;
+            //         test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+            //             let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(2, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(3, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(4, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(5, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            //             regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
-                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + saveSubdirectory; 
-                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
-                    }, exportTimeout);
+            //             assertItem.exportRegion[idxRegion].directory = basepath + "/" + saveSubdirectory; 
+            //             exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
+            //         }, exportTimeout);
     
-                    test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
-                        expect(exportRegionAck.success).toBe(exRegion.success);
-                    });
+            //         test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
+            //             expect(exportRegionAck.success).toBe(exRegion.success);
+            //         });
     
-                    test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
-                        expect(exportRegionAck.contents).toEqual(exRegion.contents);
-                    });
-                });
-            });
+            //         test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
+            //             expect(exportRegionAck.contents).toEqual(exRegion.contents);
+            //         });
+            //     });
+            // });
 
-            assertItem.importRegionAck2.map((Region, idxRegion) => {
-                describe(`Import "${assertItem.importRegion2[idxRegion].file}" from ${saveSubdirectory}`, () => {
-                    let importRegionAck: any;
-                    let importRegionAckProperties: any;
-                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        assertItem.importRegion2[idxRegion].directory = basepath + "/" + saveSubdirectory; 
-                        importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
+            // assertItem.importRegionAck2.map((Region, idxRegion) => {
+            //     describe(`Import "${assertItem.importRegion2[idxRegion].file}" from ${saveSubdirectory}`, () => {
+            //         let importRegionAck: any;
+            //         let importRegionAckProperties: any;
+            //         test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+            //             assertItem.importRegion2[idxRegion].directory = basepath + "/" + saveSubdirectory; 
+            //             importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
                         
-                        importRegionAckProperties = Object.keys(importRegionAck.regions);
-                        if (importRegionAck.message != '') {
-                            console.warn(importRegionAck.message);
-                        }
-                    }, importTimeout);
+            //             importRegionAckProperties = Object.keys(importRegionAck.regions);
+            //             if (importRegionAck.message != '') {
+            //                 console.warn(importRegionAck.message);
+            //             }
+            //         }, importTimeout);
     
-                    test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
-                        expect(importRegionAck.success).toBe(Region.success);
-                    });
+            //         test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
+            //             expect(importRegionAck.success).toBe(Region.success);
+            //         });
     
-                    test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
-                        expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
-                    });
+            //         test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
+            //             expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
+            //         });
     
-                    test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
-                        expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
-                    });
-                });
-            });
+            //         test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
+            //             expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
+            //         });
+            //     });
+            // });
         })
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -135,6 +135,9 @@ let assertItem: AssertItem = {
                     '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                     '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                     '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+                    '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
+                    '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
                 },
             },
             {
@@ -150,6 +153,9 @@ let assertItem: AssertItem = {
                     '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                     '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                     '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+                    '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
+                    '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
                 }
             },
         ],
@@ -185,18 +191,18 @@ let assertItem: AssertItem = {
         [
             {
                 success: true,
-                lengthOfRegions: 7,
+                lengthOfRegions: 10,
                 assertRegionId: {
-                    index: 6,
-                    id: 14,
+                    index: 10,
+                    id: 20,
                 },
             },
             {
                 success: true,
-                lengthOfRegions: 7,
+                lengthOfRegions: 10,
                 assertRegionId: {
-                    index: 6,
-                    id: 21,
+                    index: 10,
+                    id: 30,
                 },
             },
         ],
@@ -261,60 +267,62 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                 });
             });
 
-            // assertItem.exportRegionAck.map((exRegion, idxRegion) => {
-            //     describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
-            //         let exportRegionAck: any;
-            //         test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-            //             let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(2, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(3, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(4, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(5, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
-            //             regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+            assertItem.exportRegionAck.map((exRegion, idxRegion) => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
+                    let exportRegionAck: any;
+                    test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(2, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(3, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(4, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(5, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(9, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "", annotationStyle: { textLabel0: "CARTA REGION TEST", font: "Helvetica", fontSize: 20, fontStyle: "Normal", textPosition: 0} });
+                        regionStyle.set(10, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
-            //             assertItem.exportRegion[idxRegion].directory = basepath + "/" + saveSubdirectory; 
-            //             exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
-            //         }, exportTimeout);
+                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + saveSubdirectory; 
+                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
+                    }, exportTimeout);
     
-            //         test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
-            //             expect(exportRegionAck.success).toBe(exRegion.success);
-            //         });
+                    test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
+                        expect(exportRegionAck.success).toBe(exRegion.success);
+                    });
     
-            //         test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
-            //             expect(exportRegionAck.contents).toEqual(exRegion.contents);
-            //         });
-            //     });
-            // });
+                    test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
+                        expect(exportRegionAck.contents).toEqual(exRegion.contents);
+                    });
+                });
+            });
 
-            // assertItem.importRegionAck2.map((Region, idxRegion) => {
-            //     describe(`Import "${assertItem.importRegion2[idxRegion].file}" from ${saveSubdirectory}`, () => {
-            //         let importRegionAck: any;
-            //         let importRegionAckProperties: any;
-            //         test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-            //             assertItem.importRegion2[idxRegion].directory = basepath + "/" + saveSubdirectory; 
-            //             importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
+            assertItem.importRegionAck2.map((Region, idxRegion) => {
+                describe(`Import "${assertItem.importRegion2[idxRegion].file}" from ${saveSubdirectory}`, () => {
+                    let importRegionAck: any;
+                    let importRegionAckProperties: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        assertItem.importRegion2[idxRegion].directory = basepath + "/" + saveSubdirectory; 
+                        importRegionAck = await msgController.importRegion(assertItem.importRegion2[idxRegion].directory, assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
                         
-            //             importRegionAckProperties = Object.keys(importRegionAck.regions);
-            //             if (importRegionAck.message != '') {
-            //                 console.warn(importRegionAck.message);
-            //             }
-            //         }, importTimeout);
+                        importRegionAckProperties = Object.keys(importRegionAck.regions);
+                        if (importRegionAck.message != '') {
+                            console.warn(importRegionAck.message);
+                        }
+                    }, importTimeout);
     
-            //         test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
-            //             expect(importRegionAck.success).toBe(Region.success);
-            //         });
+                    test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
+                        expect(importRegionAck.success).toBe(Region.success);
+                    });
     
-            //         test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
-            //             expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
-            //         });
+                    test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
+                        expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
+                    });
     
-            //         test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
-            //             expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
-            //         });
-            //     });
-            // });
+                    test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
+                        expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
+                    });
+                });
+            });
         })
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -11,6 +11,7 @@
         "catalogArtificial": "set_QA/carta_artificial_catalog",
         "catalogLarge": "set_cosmos",
         "save": "set_QA/tmp",
+        "save_local": "/tmp",
         "concat_stokes": "set_StokesCube",
         "large_files": "set_lotsFiles2",
         "compressed_fits": "set_compressed_fits"

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -11,7 +11,7 @@
         "catalogArtificial": "set_QA/carta_artificial_catalog",
         "catalogLarge": "set_cosmos",
         "save": "set_QA/tmp",
-        "save_local": "/tmp",
+        "save_rhel9": "set_QA/tmp/rhel9",
         "concat_stokes": "set_StokesCube",
         "large_files": "set_lotsFiles2",
         "compressed_fits": "set_compressed_fits"


### PR DESCRIPTION
Because the text [annotation backend](https://github.com/CARTAvis/carta-backend/pull/1229) has been merged to the dev branch. The current ICD-RxJS may failed with three region-related tests:

> src/test/CASA_REGION_IMPORT_EXPORT.test.ts
> src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
> src/test/DS9_REGION_IMPORT_EXPORT.test.ts

Please note I have updated one region [ds9 file](https://drive.google.com/drive/folders/1mfFueTXWhICGsadTTK0ojWx5Kb3MvGBQ?usp=sharing), please download the updated region ds9 file to run the test.

This PR just fixes the current conflict, the text annotation ICD tests still under design phase.