### PR TITLE
fix bugs in the MATCH_STATS.test.ts

### DIFF
--- a/src/test/MATCH_STATS.test.ts
+++ b/src/test/MATCH_STATS.test.ts
@@ -274,12 +274,18 @@ describe("MATCH_STATS: Testing region stats with spatially and spectrally matche
             for (const [fileIdx, file] of assertItem.openFile.entries()) {
                 test(`Should receive 4 RegionStatsData for file_id: ${file.fileId}`, async () => {
                     for (const [statsIdx, statsReq] of assertItem.setStatsRequirements[fileIdx].entries()) {
-                        await msgController.setStatsRequirements({
-                            fileId: file.fileId,
+                        let setFileId: number;
+                        if (file.fileId === 100) {
+                            setFileId = 101;
+                        } else if (file.fileId === 101) {
+                            setFileId = 100;
+                        };
+                        msgController.setStatsRequirements({
+                            fileId: setFileId,
                             regionId: statsReq.regionId,
-                            stats: [],
+                            statsConfigs: [],
                         })
-                        await msgController.setStatsRequirements(statsReq);
+                        msgController.setStatsRequirements(statsReq);
                         RegionStatsData.push(await Stream(CARTA.RegionStatsData,1));
                     }
                 }, profileTimeout);


### PR DESCRIPTION
I found the Jenkins CI/CD server, the MATCH_STATS.test.ts usually failed on MacOS 13 (with Address Sanitizer flags carta_backend), I fixed the bug in the test code itself.
Now it should be fit (passed) the MacOS 13 on the Jenkins CI/CD server. 

At lease I tested with Address Sanitizer flags carta_backend on Ubuntu 22.04, MacOS 11, and MacOS 13. They are all passed, please check it.
