### PR TITLE
Mylin/#6 add set region annotation test

### DIFF
--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -6,7 +6,7 @@ import { execSync } from "child_process";
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
-let saveSubdirectory = config.path.save;
+let saveSubdirectory = config.path.save_unique;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
 let importTimeout = config.timeout.import;
@@ -281,7 +281,7 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                 regionStyle.set(10, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {fontSize: 13, fontStyle: 'Normal', font: 'Helvetica', coordinateSystem: 'PIXEL'} });
 
                 //Receive the Export Region ICD message Response
-                assertItem.exportRegion.directory = basepath + "/" + saveSubdirectory; 
+                assertItem.exportRegion.directory = saveSubdirectory; 
                 exportRegionAck = await msgController.exportRegion(assertItem.exportRegion.directory, assertItem.exportRegion.file, assertItem.exportRegion.type, assertItem.exportRegion.coordType, assertItem.exportRegion.fileId, regionStyle);
                 expect(exportRegionAck.contents).toEqual(assertItem.exportRegionAck.contents);
                 expect(exportRegionAck.success).toEqual(assertItem.exportRegionAck.success);
@@ -290,7 +290,7 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
             test(`(Case 3) Import the exported region file`, async () => {
                 //Request and Receive import the expored region file ICD message
                 let importRegionAck: any;
-                assertItem.importRegion.directory = basepath + "/" + saveSubdirectory; 
+                assertItem.importRegion.directory = saveSubdirectory; 
                 importRegionAck = await msgController.importRegion(assertItem.importRegion.directory, assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId);
                 
                 //Check the Responsed import region ICD message

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -2,7 +2,6 @@ import { CARTA } from "carta-protobuf";
 import { checkConnection, Stream} from './myClient';
 import { MessageController } from "./MessageController";
 import config from "./config.json";
-import { execSync } from "child_process";
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -2,6 +2,7 @@ import { CARTA } from "carta-protobuf";
 import { checkConnection, Stream} from './myClient';
 import { MessageController } from "./MessageController";
 import config from "./config.json";
+import { execSync } from "child_process";
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
@@ -330,6 +331,11 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                         expect(importRegionAckAnnotationArray).toContainEqual(assertItem.importRegionAck.regionStyles[importRegionAckIndex[index]].annotationStyle);
                     });
                 }
+            }, importTimeout);
+
+            test(`Delete the exported region file`, () => {
+                let deleteExportRegionFileCommand = assertItem.exportRegion.directory + "/" + assertItem.exportRegion.file;
+                execSync(`rm /${deleteExportRegionFileCommand}`,{encoding: 'utf-8'})
             });
         });
 

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -6,7 +6,7 @@ import { execSync } from "child_process";
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
-let saveSubdirectory = config.path.save_unique;
+let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
 let importTimeout = config.timeout.import;
@@ -281,7 +281,7 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                 regionStyle.set(10, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {fontSize: 13, fontStyle: 'Normal', font: 'Helvetica', coordinateSystem: 'PIXEL'} });
 
                 //Receive the Export Region ICD message Response
-                assertItem.exportRegion.directory = saveSubdirectory; 
+                assertItem.exportRegion.directory = basepath + "/" + saveSubdirectory; 
                 exportRegionAck = await msgController.exportRegion(assertItem.exportRegion.directory, assertItem.exportRegion.file, assertItem.exportRegion.type, assertItem.exportRegion.coordType, assertItem.exportRegion.fileId, regionStyle);
                 expect(exportRegionAck.contents).toEqual(assertItem.exportRegionAck.contents);
                 expect(exportRegionAck.success).toEqual(assertItem.exportRegionAck.success);
@@ -290,7 +290,7 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
             test(`(Case 3) Import the exported region file`, async () => {
                 //Request and Receive import the expored region file ICD message
                 let importRegionAck: any;
-                assertItem.importRegion.directory = saveSubdirectory; 
+                assertItem.importRegion.directory = basepath + "/" + saveSubdirectory; 
                 importRegionAck = await msgController.importRegion(assertItem.importRegion.directory, assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId);
                 
                 //Check the Responsed import region ICD message
@@ -332,11 +332,6 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                     });
                 }
             }, importTimeout);
-
-            test(`Delete the exported region file`, () => {
-                let deleteExportRegionFileCommand = assertItem.exportRegion.directory + "/" + assertItem.exportRegion.file;
-                execSync(`rm /${deleteExportRegionFileCommand}`,{encoding: 'utf-8'});
-            });
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -335,7 +335,7 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
 
             test(`Delete the exported region file`, () => {
                 let deleteExportRegionFileCommand = assertItem.exportRegion.directory + "/" + assertItem.exportRegion.file;
-                execSync(`rm /${deleteExportRegionFileCommand}`,{encoding: 'utf-8'})
+                execSync(`rm /${deleteExportRegionFileCommand}`,{encoding: 'utf-8'});
             });
         });
 

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -18,10 +18,10 @@ interface AssertItem {
     addTilesRequire: CARTA.IAddRequiredTiles;
     precisionDigits: number;
     setRegion: CARTA.ISetRegion[];
+    exportRegion: CARTA.IExportRegion;
+    exportRegionAck: CARTA.IExportRegionAck;
     // importRegion: CARTA.IImportRegion;
     // importRegionAck: CARTA.IImportRegionAck;
-    // exportRegion: CARTA.IExportRegion[];
-    // exportRegionAck: CARTA.IExportRegionAck[];
     // importRegion2: CARTA.IImportRegion[];
 };
 let assertItem: AssertItem = {
@@ -141,7 +141,18 @@ let assertItem: AssertItem = {
                 rotation: 0,
             }
         },
-    ]
+    ],
+    exportRegion: {
+        coordType: CARTA.CoordinateType.WORLD,
+        file: "set_region_annotation_test_pixel.crtf",
+        fileId: 0,
+        type: CARTA.FileType.CRTF,
+        regionStyles: {},
+    },
+    exportRegionAck: {
+        contents: [],
+        success: true
+    }
     // importRegion:
     // {
     //     contents: [],
@@ -210,56 +221,6 @@ let assertItem: AssertItem = {
     //         '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
     //     },
     // },
-    // exportRegion:
-    //     [
-    //         {
-    //             coordType: CARTA.CoordinateType.WORLD,
-    //             file: "M17_SWex_testRegions_pix_export_to_world.reg",
-    //             fileId: 0,
-    //             type: CARTA.FileType.DS9_REG,
-    //             regionStyles: {
-    //                 '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //                 '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
-    //                 '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //             },
-    //         },
-    //         {
-    //             coordType: CARTA.CoordinateType.PIXEL,
-    //             file: "M17_SWex_testRegions_pix_export_to_pix.reg",
-    //             fileId: 0,
-    //             type: CARTA.FileType.DS9_REG,
-    //             regionStyles: {
-    //                 '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
-    //                 '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //                 '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
-    //                 '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //             }
-    //         },
-    //     ],
-    // exportRegionAck:
-    //     [
-    //         {
-    //             success: true,
-    //             contents: [],
-    //         },
-    //         {
-    //             success: true,
-    //             contents: [],
-    //         },
-    //     ],
     // importRegion2:
     //     [
     //         {
@@ -316,6 +277,31 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                     expect(setRegionAckResponse.success).toEqual(true);
                     expect(setRegionAckResponse.regionId).toEqual(index + 1);
                 };
+            });
+
+            test(`(Case 2) Export all annotation RegionTypes as crtf pixel (CASA region) format`, async () => {
+                //Request the Export Region ICD message
+                let exportRegionAck: any;
+                let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: '”', color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(2, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(3, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(4, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(5, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(6, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(7, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                regionStyle.set(8, { name: "", color: '#FFBA01', lineWidth: 1, dashList: [], annotationStyle: {font: "Helvetica", fontSize: 20, fontStyle: "Normal", textLabel0: "Double click to edit text", textPosition: 0}});
+                regionStyle.set(9, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {coordinateSystem: "PIXEL", font: "Helvetica", fontSize: 20, fontStyle: "Normal", isEastArrow: true, isNorthArrow: true, textLabel0: "N", textLabel1: "E"}});
+                regionStyle.set(10, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {fontSize: 13, fontStyle: 'Normal', font: 'Helvetica', coordinateSystem: 'PIXEL'} });
+
+                //Receive the Export Region ICD message Response
+                assertItem.exportRegion.directory = basepath + "/" + saveSubdirectory; 
+                exportRegionAck = await msgController.exportRegion(assertItem.exportRegion.directory, assertItem.exportRegion.file, assertItem.exportRegion.type, assertItem.exportRegion.coordType, assertItem.exportRegion.fileId, regionStyle);
+                expect(exportRegionAck.contents).toEqual(assertItem.exportRegionAck.contents);
+                expect(exportRegionAck.success).toEqual(assertItem.exportRegionAck.success);
+            }, exportTimeout);
+
+            test(`(Case 3) Import the exported region file`, async () => {
+
             });
         });
     });

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -1,0 +1,200 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let saveSubdirectory = config.path.save;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+let exportTimeout = config.timeout.export;
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesRequire: CARTA.IAddRequiredTiles;
+    precisionDigits: number;
+    importRegion: CARTA.IImportRegion;
+    importRegionAck: CARTA.IImportRegionAck;
+    exportRegion: CARTA.IExportRegion[];
+    exportRegionAck: CARTA.IExportRegionAck[];
+    importRegion2: CARTA.IImportRegion[];
+};
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    addTilesRequire:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    precisionDigits: 4,
+    // importRegion:
+    // {
+    //     contents: [],
+    //     directory: regionSubdirectory,
+    //     file: "M17_SWex_testRegions_pix.reg",
+    //     groupId: 0,
+    //     type: CARTA.FileType.DS9_REG,
+    // },
+    // importRegionAck:
+    // {
+    //     success: true,
+    //     regions: {
+    //         '1': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 40, y: 100 }],
+    //             regionType: CARTA.RegionType.RECTANGLE,
+    //         },
+    //         '2': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 40 }],
+    //             regionType: CARTA.RegionType.RECTANGLE,
+    //         },
+    //         '3': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 40 }],
+    //             rotation: 45,
+    //             regionType: CARTA.RegionType.RECTANGLE,
+    //         },
+    //         '4': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 600 }, { x: 400, y: 400 }],
+    //             regionType: CARTA.RegionType.POLYGON,
+    //         },
+    //         '5': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 200 }],
+    //             regionType: CARTA.RegionType.ELLIPSE,
+    //         },
+    //         '6': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 20 }],
+    //             regionType: CARTA.RegionType.ELLIPSE,
+    //             rotation: 45,
+    //         },
+    //         '7': {
+    //             controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 300}],
+    //             regionType: CARTA.RegionType.LINE,
+    //         },
+    //         '8': {
+    //             controlPoints: [{ x: 320, y: 400 }, {x: 369.99951171875, y: 449.99951171875}],
+    //             regionType: CARTA.RegionType.ANNVECTOR,
+    //         },
+    //         '9': {
+    //             controlPoints: [{ x: 320, y: 400 }, {}],
+    //             regionType: CARTA.RegionType.ANNTEXT,
+    //         },
+    //         '10': {
+    //             controlPoints: [{ x: 320, y: 300 }],
+    //             regionType: CARTA.RegionType.POINT,
+    //         },
+    //     },
+    //     regionStyles: {
+    //         '1': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '2': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '3': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '4': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '5': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '6': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '7': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //         '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //     },
+    // },
+    // exportRegion:
+    //     [
+    //         {
+    //             coordType: CARTA.CoordinateType.WORLD,
+    //             file: "M17_SWex_testRegions_pix_export_to_world.reg",
+    //             fileId: 0,
+    //             type: CARTA.FileType.DS9_REG,
+    //             regionStyles: {
+    //                 '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //                 '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
+    //                 '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //             },
+    //         },
+    //         {
+    //             coordType: CARTA.CoordinateType.PIXEL,
+    //             file: "M17_SWex_testRegions_pix_export_to_pix.reg",
+    //             fileId: 0,
+    //             type: CARTA.FileType.DS9_REG,
+    //             regionStyles: {
+    //                 '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+    //                 '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //                 '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "", annotationStyle: {textLabel0: 'CARTA REGION TEST'} },
+    //                 '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+    //             }
+    //         },
+    //     ],
+    // exportRegionAck:
+    //     [
+    //         {
+    //             success: true,
+    //             contents: [],
+    //         },
+    //         {
+    //             success: true,
+    //             contents: [],
+    //         },
+    //     ],
+    // importRegion2:
+    //     [
+    //         {
+    //             directory: saveSubdirectory,
+    //             contents: [],
+    //             file: "M17_SWex_testRegions_pix_export_to_world.reg",
+    //             groupId: 0,
+    //             type: CARTA.FileType.DS9_REG,
+    //         },
+    //         {
+    //             directory: saveSubdirectory,
+    //             contents: [],
+    //             file: "M17_SWex_testRegions_pix_export_to_pix.reg",
+    //             groupId: 0,
+    //             type: CARTA.FileType.DS9_REG,
+    //         },
+    //     ],
+};
+
+let basepath: string;
+describe("Testing set region ICD message to all annotation RegionTypes and export and import for CASA pixel format", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        afterAll(() => msgController.closeConnection());
+
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+    });
+});

--- a/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
+++ b/src/test/SET_REGION_ANNOTATION_EXPORT_IMPORT_CASA_PIXEL.test.ts
@@ -5,7 +5,6 @@ import config from "./config.json";
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
-let regionSubdirectory = config.path.region;
 let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
@@ -20,9 +19,8 @@ interface AssertItem {
     setRegion: CARTA.ISetRegion[];
     exportRegion: CARTA.IExportRegion;
     exportRegionAck: CARTA.IExportRegionAck;
-    // importRegion: CARTA.IImportRegion;
-    // importRegionAck: CARTA.IImportRegionAck;
-    // importRegion2: CARTA.IImportRegion[];
+    importRegion: CARTA.IImportRegion;
+    importRegionAck: CARTA.IImportRegionAck;
 };
 let assertItem: AssertItem = {
     openFile:
@@ -44,7 +42,7 @@ let assertItem: AssertItem = {
         compressionQuality: 11,
         compressionType: CARTA.CompressionType.ZFP,
     },
-    precisionDigits: 4,
+    precisionDigits: 3,
     setRegion: [
         {
             fileId: 0,
@@ -119,8 +117,8 @@ let assertItem: AssertItem = {
             regionId: -1,
             regionInfo: {
                 regionType: CARTA.RegionType.ANNTEXT,
-                controlPoints: [{x: 260.93920595533507, y: 346.894540942928}, {x: 408.2232666015625, y: 39.702233250620345}],
-                rotation: 0,
+                controlPoints: [{x: 260.939208984375, y: 346.894500732421}, {x: 400.28278943386033, y: 107.19604796038084}],
+                rotation: 45,
             }
         },
         {
@@ -152,92 +150,80 @@ let assertItem: AssertItem = {
     exportRegionAck: {
         contents: [],
         success: true
-    }
-    // importRegion:
-    // {
-    //     contents: [],
-    //     directory: regionSubdirectory,
-    //     file: "M17_SWex_testRegions_pix.reg",
-    //     groupId: 0,
-    //     type: CARTA.FileType.DS9_REG,
-    // },
-    // importRegionAck:
-    // {
-    //     success: true,
-    //     regions: {
-    //         '1': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 40, y: 100 }],
-    //             regionType: CARTA.RegionType.RECTANGLE,
-    //         },
-    //         '2': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 40 }],
-    //             regionType: CARTA.RegionType.RECTANGLE,
-    //         },
-    //         '3': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 40 }],
-    //             rotation: 45,
-    //             regionType: CARTA.RegionType.RECTANGLE,
-    //         },
-    //         '4': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 600 }, { x: 400, y: 400 }],
-    //             regionType: CARTA.RegionType.POLYGON,
-    //         },
-    //         '5': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 200 }],
-    //             regionType: CARTA.RegionType.ELLIPSE,
-    //         },
-    //         '6': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 20 }],
-    //             regionType: CARTA.RegionType.ELLIPSE,
-    //             rotation: 45,
-    //         },
-    //         '7': {
-    //             controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 300}],
-    //             regionType: CARTA.RegionType.LINE,
-    //         },
-    //         '8': {
-    //             controlPoints: [{ x: 320, y: 400 }, {x: 369.99951171875, y: 449.99951171875}],
-    //             regionType: CARTA.RegionType.ANNVECTOR,
-    //         },
-    //         '9': {
-    //             controlPoints: [{ x: 320, y: 400 }, {}],
-    //             regionType: CARTA.RegionType.ANNTEXT,
-    //         },
-    //         '10': {
-    //             controlPoints: [{ x: 320, y: 300 }],
-    //             regionType: CARTA.RegionType.POINT,
-    //         },
-    //     },
-    //     regionStyles: {
-    //         '1': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '2': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '3': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '4': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '5': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '6': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '7': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '9': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //         '10': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
-    //     },
-    // },
-    // importRegion2:
-    //     [
-    //         {
-    //             directory: saveSubdirectory,
-    //             contents: [],
-    //             file: "M17_SWex_testRegions_pix_export_to_world.reg",
-    //             groupId: 0,
-    //             type: CARTA.FileType.DS9_REG,
-    //         },
-    //         {
-    //             directory: saveSubdirectory,
-    //             contents: [],
-    //             file: "M17_SWex_testRegions_pix_export_to_pix.reg",
-    //             groupId: 0,
-    //             type: CARTA.FileType.DS9_REG,
-    //         },
-    //     ],
+    },
+    importRegion:
+    {
+        contents: [],
+        directory: saveSubdirectory,
+        file: "set_region_annotation_test_pixel.crtf",
+        groupId: 0,
+        type: CARTA.FileType.CRTF,
+    },
+    importRegionAck:
+    {
+        success: true,
+        regions: {
+            '11': {
+                controlPoints: [{x: 163, y: 565}],
+                regionType: CARTA.RegionType.ANNPOINT,
+            },
+            '12': {
+                controlPoints: [{x: 270, y: 618}, {x: 219, y: 560}],
+                regionType: CARTA.RegionType.ANNLINE,
+                rotation: 318.95805304638026
+            },
+            '13': {
+                controlPoints: [{x: 309, y: 587}, {x: 36, y: 44}],
+                regionType: CARTA.RegionType.ANNRECTANGLE,
+            },
+            '14': {
+                controlPoints: [{x: 388, y: 587}, {x: 33.7, y: 11.9}],
+                regionType: CARTA.RegionType.ANNELLIPSE,
+            },
+            '15': {
+                controlPoints: [{x: 175.5794044665014, y: 511.6588089330025}, 
+                    {x: 125.95161290322585, y: 464.01612903225805}, 
+                    {x: 169.62406947890827, y: 446.1501240694789}, 
+                    {x: 225.2071960297768, y: 464.01612903225805}, 
+                    {x: 175.5794044665014, y: 471.95657568238215}],
+                regionType: CARTA.RegionType.ANNPOLYGON,
+            },
+            '16': {
+                controlPoints: [{x: 265, y: 458}, {x: 299, y: 520}, {x: 324, y: 446}],
+                regionType: CARTA.RegionType.ANNPOLYLINE,
+            },
+            '17': {
+                controlPoints: [{x: 340, y: 533}, {x: 416, y: 474}],
+                regionType: CARTA.RegionType.ANNVECTOR,
+                rotation: 52.177245850855,
+            },
+            '18': {
+                controlPoints: [{x: 260.939208984375, y: 346.8945007324219}, {x: 400.28278943386033, y: 107.19604796038084}],
+                regionType: CARTA.RegionType.ANNTEXT,
+                rotation: 45,
+            },
+            '19': {
+                controlPoints: [{x: 157.71339950372214, y: 132.50248138957818}, {x: 100, y: 100}],
+                regionType: CARTA.RegionType.ANNCOMPASS,
+            },
+            '20': {
+                controlPoints: [{x: 362, y: 219}, {x: 485, y: 285}],
+                regionType: CARTA.RegionType.ANNRULER,
+            },
+        },
+        regionStyles: {
+            '11': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {pointWidth: 1,fontStyle: 'bold',font: 'Helvetica',fontSize: 10} },
+            '12': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontStyle: 'bold', font: 'Helvetica', fontSize: 10} },
+            '13': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontStyle: 'bold', font: 'Helvetica', fontSize: 10} },
+            '14': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontStyle: 'bold', font: 'Helvetica', fontSize: 10} },
+            '15': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontStyle: 'bold', font: 'Helvetica', fontSize: 10} },
+            '16': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontStyle: 'bold', font: 'Helvetica', fontSize: 10} },
+            '17': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontStyle: 'bold', font: 'Helvetica', fontSize: 10} },
+            '18': { name: "", color: '#FFBA01', lineWidth: 1, dashList: [0], annotationStyle: {font: "Helvetica", fontSize: 20, fontStyle: "Normal", textLabel0: "Double click to edit text", textPosition: 0} },
+            '19': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {font: "Helvetica", fontSize: 20, fontStyle: "Normal", isEastArrow: true, isNorthArrow: true, textLabel0: "N", textLabel1: "E"} },
+            '20': { name: "", color: '#FFBA01', lineWidth: 2, dashList: [0], annotationStyle: {fontSize: 13, fontStyle: 'normal', font: 'Helvetica'} },
+        },
+    },
 };
 
 let basepath: string;
@@ -282,7 +268,7 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
             test(`(Case 2) Export all annotation RegionTypes as crtf pixel (CASA region) format`, async () => {
                 //Request the Export Region ICD message
                 let exportRegionAck: any;
-                let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: '”', color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
+                let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: '', color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
                 regionStyle.set(2, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
                 regionStyle.set(3, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
                 regionStyle.set(4, { name: "", color: '#FFBA01', lineWidth: 2, dashList: [], annotationStyle: {} });
@@ -301,8 +287,52 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
             }, exportTimeout);
 
             test(`(Case 3) Import the exported region file`, async () => {
+                //Request and Receive import the expored region file ICD message
+                let importRegionAck: any;
+                assertItem.importRegion.directory = basepath + "/" + saveSubdirectory; 
+                importRegionAck = await msgController.importRegion(assertItem.importRegion.directory, assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId);
+                
+                //Check the Responsed import region ICD message
+                let importRegionAckIndex = Object.keys(importRegionAck.regions);
+                //Check each region
+                for (let index = 0; index < importRegionAckIndex.length; index++) {
+                    //Check the controlPoints
+                    for (let controlPointsArrayLength = 0; controlPointsArrayLength < importRegionAck.regions[importRegionAckIndex[index]].controlPoints.length; controlPointsArrayLength++) {
+                        expect(importRegionAck.regions[importRegionAckIndex[index]].controlPoints[controlPointsArrayLength].x).toBeCloseTo(assertItem.importRegionAck.regions[importRegionAckIndex[index]].controlPoints[controlPointsArrayLength].x, assertItem.precisionDigits);
+                        expect(importRegionAck.regions[importRegionAckIndex[index]].controlPoints[controlPointsArrayLength].y).toBeCloseTo(assertItem.importRegionAck.regions[importRegionAckIndex[index]].controlPoints[controlPointsArrayLength].y, assertItem.precisionDigits);
+                    };
 
+                    //Check the rotation
+                    if (importRegionAck.regions[importRegionAckIndex[index]].rotation) {
+                        expect(importRegionAck.regions[importRegionAckIndex[index]].rotation).toBeCloseTo(assertItem.importRegionAck.regions[importRegionAckIndex[index]].rotation);
+                    };
+
+                    //Check the regionType
+                    expect(importRegionAck.regions[importRegionAckIndex[index]].regionType).toEqual(assertItem.importRegionAck.regions[importRegionAckIndex[index]].regionType);
+                }
+
+                //Check each regionStyles
+                for (let index = 0; index < importRegionAckIndex.length; index++) {
+                    let regionStylesProperties = Object.keys(importRegionAck.regionStyles[importRegionAckIndex[index]]);
+                    //Check dashList
+                    expect(importRegionAck.regionStyles[importRegionAckIndex[index]].dashList).toEqual(assertItem.importRegionAck.regionStyles[importRegionAckIndex[index]].dashList);
+
+                    //Check colour
+                    expect(importRegionAck.regionStyles[importRegionAckIndex[index]].color).toEqual(assertItem.importRegionAck.regionStyles[importRegionAckIndex[index]].color);
+
+                    //Check lineWidth
+                    expect(importRegionAck.regionStyles[importRegionAckIndex[index]].lineWidth).toEqual(assertItem.importRegionAck.regionStyles[importRegionAckIndex[index]].lineWidth);
+
+                    //Check annotationStyle
+                    let annotationStyleProperties = Object.keys(importRegionAck.regionStyles[importRegionAckIndex[index]].annotationStyle);
+                    annotationStyleProperties.map((property, index) => {
+                        let importRegionAckAnnotationArray = new Array(importRegionAck.regionStyles[importRegionAckIndex[index]].annotationStyle);
+                        expect(importRegionAckAnnotationArray).toContainEqual(assertItem.importRegionAck.regionStyles[importRegionAckIndex[index]].annotationStyle);
+                    });
+                }
             });
         });
+
+        afterAll(() => msgController.closeConnection());
     });
 });

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -11,7 +11,6 @@
         "catalogArtificial": "set_QA/carta_artificial_catalog",
         "catalogLarge": "set_cosmos",
         "save": "set_QA/tmp",
-        "save_unique": "/tmp",
         "save_rhel9": "set_QA/tmp/rhel9",
         "concat_stokes": "set_StokesCube",
         "large_files": "set_lotsFiles2",

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -11,6 +11,7 @@
         "catalogArtificial": "set_QA/carta_artificial_catalog",
         "catalogLarge": "set_cosmos",
         "save": "set_QA/tmp",
+        "save_unique": "/tmp",
         "save_rhel9": "set_QA/tmp/rhel9",
         "concat_stokes": "set_StokesCube",
         "large_files": "set_lotsFiles2",


### PR DESCRIPTION
#6 
This is the new added set region annotation test.
It will create a new region ICD and check the response ICD message.
Then export the region file to (image folder path)/set_QA/tmp and then the test will import this region file.
In the final stage, the test deletes the new created region file in (image folder path)/set_QA/tmp
