### PR TITLE
Mylin/#15 add new histogram test modify old

### DIFF
--- a/src/test/PER_CUBE_HISTOGRAM.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM.test.ts
@@ -45,9 +45,7 @@ let assertItem: AssertItem = {
     setHistogramRequirements: {
         fileId: 0,
         regionId: -2,
-        histograms: [
-            { channel: -2, numBins: -1 },
-        ],
+        histograms: [{bounds: {min: 0, max: 0}, channel: -2, numBins: -1, fixedBounds: false, fixedNumBins: false}],
     },
     regionHistogramData: {
         regionId: -2,

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -53,9 +53,7 @@ let assertItem: AssertItem = {
     setHistogramRequirements: {
         fileId: 0,
         regionId: -2,
-        histograms: [
-            { channel: -2, numBins: -1 },
-        ],
+        histograms: [{bounds: {min: 0, max: 0}, channel: -2, numBins: -1, fixedBounds: false, fixedNumBins: false}],
     },
     cancelHistogramRequirements: {
         fileId: 0,

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -11,6 +11,7 @@ let readFileTimeout = config.timeout.readFile;
 let cubeHistogramTimeout = config.timeout.cubeHistogram;
 let messageReturnTimeout = config.timeout.readFile;
 let cancelTimeout = config.timeout.cancel;
+let firstHistogramDataTimeout = config.timeout.firstHistogramCancellation;
 
 interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
     lengthOfHistogramBins: number;
@@ -119,7 +120,7 @@ describe("PER_CUBE_HISTOGRAM_CANCELLATION: Testing calculations of the per-cube 
                 msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
                 RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
                 ReceiveProgress = RegionHistogramData[0].progress;
-            }, 10000);
+            }, firstHistogramDataTimeout);
 
             test(`(Step2) REGION_HISTOGRAM_DATA.progress > 0 and REGION_HISTOGRAM_DATA.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
                 expect(RegionHistogramData[0].progress).toBeGreaterThan(0);

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -54,9 +54,7 @@ let assertItem: AssertItem = {
     setHistogramRequirements: {
         fileId: 0,
         regionId: -2,
-        histograms: [
-            { channel: -2, numBins: -1 },
-        ],
+        histograms: [{bounds: {min: 0, max: 0}, channel: -2, numBins: -1, fixedBounds: false, fixedNumBins: false}],
     },
     cancelHistogramRequirements: {
         fileId: 0,

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -116,7 +116,7 @@ describe("PER_CUBE_HISTOGRAM_CANCELLATION: Testing calculations of the per-cube 
         let RegionHistogramData: CARTA.RegionHistogramData;
         let RegionHistogramDataTemp1 = []
         describe(`Set histogram requirements:`, () => {
-            test(`(Step1) "${assertItem.openFile.file}" REGION_HISTOGRAM_DATA should arrive completely within 10000 ms:`, async () => {
+            test(`(Step1) "${assertItem.openFile.file}" REGION_HISTOGRAM_DATA should arrive completely within ${firstHistogramDataTimeout} ms:`, async () => {
                 msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
                 RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
                 ReceiveProgress = RegionHistogramData[0].progress;

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -54,7 +54,9 @@ let assertItem: AssertItem = {
     setHistogramRequirements: {
         fileId: 0,
         regionId: -2,
-        histograms: [{bounds: {min: 0, max: 0}, channel: -2, numBins: -1, fixedBounds: false, fixedNumBins: false}],
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
     },
     cancelHistogramRequirements: {
         fileId: 0,

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
@@ -45,9 +45,7 @@ let assertItem: AssertItem = {
     setHistogramRequirements: {
         fileId: 0,
         regionId: -2,
-        histograms: [
-            { channel: -2, numBins: -1 },
-        ],
+        histograms: [{bounds: {min: 0, max: 0}, channel: -2, numBins: -1, fixedBounds: false, fixedNumBins: false}],
     },
     regionHistogramData: {
         regionId: -2,

--- a/src/test/SET_HISTOGRAMCONFIG.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG.test.ts
@@ -261,6 +261,23 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                     expect(data.stokes).toEqual(assertItem.setImageChannel.stokes);
                 })
             });
+
+            test(`(Case 3) Reset the Histogram to default and check the correction of RegionHistogramData:`, async () => {
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements[2]);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+                expect(RegionHistogramData[0].channel).toEqual(assertItem.ResponseRegionHistogramData[3].channel);
+                expect(RegionHistogramData[0].progress).toEqual(assertItem.ResponseRegionHistogramData[3].progress);
+                expect(RegionHistogramData[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[3].regionId);
+                expect(RegionHistogramData[0].stokes).toEqual(assertItem.ResponseRegionHistogramData[3].stokes);
+                expect(RegionHistogramData[0].config.bounds).toEqual(assertItem.ResponseRegionHistogramData[3].config.bounds);
+                expect(RegionHistogramData[0].config.numBins).toEqual(assertItem.ResponseRegionHistogramData[3].config.numBins);
+                expect(RegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.mean, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.numBins).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.numBins, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.stdDev).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.stdDev, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.bins.length).toEqual(assertItem.ResponseRegionHistogramData[3].histograms.numBins);
+            });
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/SET_HISTOGRAMCONFIG.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG.test.ts
@@ -16,13 +16,14 @@ interface AssertItem {
     precisionDigits: number;
     setHistogramRequirements: CARTA.ISetHistogramRequirements[];
     setImageChannel: CARTA.ISetImageChannels;
+    ResponseRegionHistogramData: CARTA.IRegionHistogramData[];
 };
 
 let assertItem: AssertItem = {
     openFile:
     {
         directory: testSubdirectory,
-        file: "M17_SWex.fits",
+        file: "HH211_IQU.fits",
         fileId: 0,
         hdu: "0",
         renderMode: CARTA.RenderMode.RASTER,
@@ -40,6 +41,11 @@ let assertItem: AssertItem = {
     },
     precisionDigits: 6,
     setHistogramRequirements: [
+        {
+            fileId: 0,
+            regionId: -1,
+            histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "z", fixedBounds: false, fixedNumBins: false}]
+        },
         {
             fileId: 0,
             regionId: -1,
@@ -62,5 +68,108 @@ let assertItem: AssertItem = {
             compressionQuality: 11,
             tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50348033, 50348035, 50348032],
         },
-    }
+    },
+    ResponseRegionHistogramData: 
+    [
+        {
+            progress: 1,
+            regionId: -1,
+            config: 
+            {
+                bounds: {},
+                numBins: -1
+            },
+            histograms: 
+            {
+                binWidth: 0.0002482116688042879,
+                firstBinCenter: -0.12420587241649628,
+                mean: 0.000008066841056845398,
+                numBins: 1049,
+                stdDev: 0.014460244218400708,
+            }
+        },
+        {
+            progress: 1,
+            regionId: -1,
+            stokes: 1,
+            config: 
+            {
+                fixedBounds: true, 
+                fixedNumBins: true, 
+                numBins: 2
+            },
+            histograms: 
+            {
+                binWidth: 0.5688369274139404,
+                bins: [0, 736448],
+                firstBinCenter: -0.7155815362930298,
+                mean: -0.0000026881257400475778,
+                numBins: 2,
+                stdDev: 0.0142919735819505,
+            }
+        }
+    ]
 }
+
+let basepath: string;
+describe("Testing set region ICD message to all annotation RegionTypes and export and import for CASA pixel format", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        afterAll(() => msgController.closeConnection());
+
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesRequire);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements[0]);
+                let RegionHistogramDataReponse = await Stream(CARTA.RegionHistogramData,1);
+                expect(RegionHistogramDataReponse[0].progress).toEqual(assertItem.ResponseRegionHistogramData[0].progress);
+                expect(RegionHistogramDataReponse[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[0].regionId);
+                expect(RegionHistogramDataReponse[0].config.bounds).toEqual(assertItem.ResponseRegionHistogramData[0].config.bounds);
+                expect(RegionHistogramDataReponse[0].config.numBins).toEqual(assertItem.ResponseRegionHistogramData[0].config.numBins);
+                expect(RegionHistogramDataReponse[0].histograms.binWidth).toBeCloseTo(assertItem.ResponseRegionHistogramData[0].histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramDataReponse[0].histograms.firstBinCenter).toBeCloseTo(assertItem.ResponseRegionHistogramData[0].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramDataReponse[0].histograms.mean).toBeCloseTo(assertItem.ResponseRegionHistogramData[0].histograms.mean, assertItem.precisionDigits);
+                expect(RegionHistogramDataReponse[0].histograms.numBins).toBeCloseTo(assertItem.ResponseRegionHistogramData[0].histograms.numBins, assertItem.precisionDigits);
+                expect(RegionHistogramDataReponse[0].histograms.stdDev).toBeCloseTo(assertItem.ResponseRegionHistogramData[0].histograms.stdDev, assertItem.precisionDigits);
+            }, openFileTimeout);
+
+            // let RegionHistogramData: CARTA.IRegionHistogramData;
+            // test(`(Case 1) set Bounds and NumBins, and then receive the first RegionHistogramData:`, async () => {
+            //     console.log(assertItem.setHistogramRequirements[0])
+            //     msgController.setHistogramRequirements(assertItem.setHistogramRequirements[0]);
+            //     RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+            //     console.log(RegionHistogramData);
+            //     // msgController.setHistogramRequirements(assertItem.setHistogramRequirements[0]);
+            // });
+
+            // test(`(Case 1) Check the correction of the first RegionHistogramData`, () => {
+            //     // expect(RegionHistogramData[0].progress).toEqual(assertItem.ResponseRegionHistogramData[0].progress);
+            //     // expect(RegionHistogramData[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[0].regionId);
+            //     // expect(RegionHistogramData[0].stokes).toEqual(assertItem.ResponseRegionHistogramData[0].stokes);
+            //     // expect(RegionHistogramData[0].config.fixedBounds).toEqual(assertItem.ResponseRegionHistogramData[0].config.fixedBounds);
+            // });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/SET_HISTOGRAMCONFIG.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG.test.ts
@@ -2,6 +2,7 @@ import { CARTA } from "carta-protobuf";
 import { checkConnection, Stream} from './myClient';
 import { MessageController } from "./MessageController";
 import config from "./config.json";
+import { take } from 'rxjs/operators';
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
@@ -11,7 +12,6 @@ let openFileTimeout = config.timeout.openFile;
 
 interface AssertItem {
     openFile: CARTA.IOpenFile;
-    setCursor: CARTA.ISetCursor;
     addTilesRequire: CARTA.IAddRequiredTiles;
     precisionDigits: number;
     setHistogramRequirements: CARTA.ISetHistogramRequirements[];
@@ -27,10 +27,6 @@ let assertItem: AssertItem = {
         fileId: 0,
         hdu: "0",
         renderMode: CARTA.RenderMode.RASTER,
-    },
-    setCursor: {
-        fileId: 0,
-        point: { x: 1, y: 1 },
     },
     addTilesRequire:
     {
@@ -94,6 +90,7 @@ let assertItem: AssertItem = {
             stokes: 1,
             config: 
             {
+                bounds:{min: -1, max: 0.1376738934777677},
                 fixedBounds: true, 
                 fixedNumBins: true, 
                 numBins: 2
@@ -106,6 +103,47 @@ let assertItem: AssertItem = {
                 mean: -0.0000026881257400475778,
                 numBins: 2,
                 stdDev: 0.0142919735819505,
+            }
+        },
+        {
+            channel: 3,
+            progress: 1,
+            regionId: -1,
+            stokes: 1,
+            config: 
+            {
+                bounds:{min: -1, max: 0.1376738934777677},
+                fixedBounds: true, 
+                fixedNumBins: true, 
+                numBins: 2
+            },
+            histograms: 
+            {
+                binWidth: 0.5688369274139404,
+                bins: [0, 736705],
+                firstBinCenter: -0.7155815362930298,
+                mean: 0.000002222024835655828,
+                numBins: 2,
+                stdDev: 0.002096762523721388,
+            }
+        },
+        {
+            channel: 3,
+            progress: 1,
+            regionId: -1,
+            stokes: 1,
+            config: 
+            {
+                bounds:{},
+                numBins: -1
+            },
+            histograms: 
+            {
+                binWidth: 0.00003724902853718959,
+                firstBinCenter: -0.016793109476566315,
+                mean: 0.000002222024835655828,
+                numBins: 1049,
+                stdDev: 0.002096762523721388,
             }
         }
     ]
@@ -138,8 +176,8 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
 
                 msgController.addRequiredTiles(assertItem.addTilesRequire);
                 let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
-                msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
-                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            
+                //click Histogram widget
                 msgController.setHistogramRequirements(assertItem.setHistogramRequirements[0]);
                 let RegionHistogramDataReponse = await Stream(CARTA.RegionHistogramData,1);
                 expect(RegionHistogramDataReponse[0].progress).toEqual(assertItem.ResponseRegionHistogramData[0].progress);
@@ -153,21 +191,76 @@ describe("Testing set region ICD message to all annotation RegionTypes and expor
                 expect(RegionHistogramDataReponse[0].histograms.stdDev).toBeCloseTo(assertItem.ResponseRegionHistogramData[0].histograms.stdDev, assertItem.precisionDigits);
             }, openFileTimeout);
 
-            // let RegionHistogramData: CARTA.IRegionHistogramData;
-            // test(`(Case 1) set Bounds and NumBins, and then receive the first RegionHistogramData:`, async () => {
-            //     console.log(assertItem.setHistogramRequirements[0])
-            //     msgController.setHistogramRequirements(assertItem.setHistogramRequirements[0]);
-            //     RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
-            //     console.log(RegionHistogramData);
-            //     // msgController.setHistogramRequirements(assertItem.setHistogramRequirements[0]);
-            // });
+            let RegionHistogramData: CARTA.IRegionHistogramData;
+            test(`(Case 1) set Bounds and NumBins, and then receive the first RegionHistogramData:`, async () => {
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements[1]);
+                RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+            });
 
-            // test(`(Case 1) Check the correction of the first RegionHistogramData`, () => {
-            //     // expect(RegionHistogramData[0].progress).toEqual(assertItem.ResponseRegionHistogramData[0].progress);
-            //     // expect(RegionHistogramData[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[0].regionId);
-            //     // expect(RegionHistogramData[0].stokes).toEqual(assertItem.ResponseRegionHistogramData[0].stokes);
-            //     // expect(RegionHistogramData[0].config.fixedBounds).toEqual(assertItem.ResponseRegionHistogramData[0].config.fixedBounds);
-            // });
+            test(`(Case 1) Check the correction of the first RegionHistogramData`, () => {
+                expect(RegionHistogramData[0].progress).toEqual(assertItem.ResponseRegionHistogramData[1].progress);
+                expect(RegionHistogramData[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[1].regionId);
+                expect(RegionHistogramData[0].stokes).toEqual(assertItem.ResponseRegionHistogramData[1].stokes);
+                expect(RegionHistogramData[0].config.bounds).toEqual(assertItem.ResponseRegionHistogramData[1].config.bounds);
+                expect(RegionHistogramData[0].config.fixedBounds).toEqual(assertItem.ResponseRegionHistogramData[1].config.fixedBounds);
+                expect(RegionHistogramData[0].config.fixedNumBins).toEqual(assertItem.ResponseRegionHistogramData[1].config.fixedNumBins);
+                expect(RegionHistogramData[0].config.numBins).toEqual(assertItem.ResponseRegionHistogramData[1].config.numBins);
+                expect(RegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.ResponseRegionHistogramData[1].histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.ResponseRegionHistogramData[1].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.ResponseRegionHistogramData[1].histograms.mean, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.numBins).toBeCloseTo(assertItem.ResponseRegionHistogramData[1].histograms.numBins, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.stdDev).toBeCloseTo(assertItem.ResponseRegionHistogramData[1].histograms.stdDev, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.bins).toEqual(assertItem.ResponseRegionHistogramData[1].histograms.bins);
+            });
+
+            let RegionHistogramDataResponse: CARTA.RegionHistogramData[] = [];
+            let RasterTileDataResponse: any = [];
+            test(`(Case 2) Set image channel, and then receive the RegionHistogramData * 2 + RasterTileData * 20 + RasterTileSync * 2:`, async () => {
+                msgController.setChannels(assertItem.setImageChannel);
+                msgController.histogramStream.pipe(take(2)).subscribe({
+                    next: (data) => {
+                        RegionHistogramDataResponse.push(data)
+                    }
+                })
+                RasterTileDataResponse = await Stream(CARTA.RasterTileData,22);
+            });
+
+            test(`(Case 2) Check the correction of RegionHistogramData * 2 + RasterTileData * 20 + RasterTileSync * 2:`, () => {
+                let firstRegionHistogramData = RegionHistogramDataResponse.filter(data => data.histograms.numBins == 2);
+                expect(firstRegionHistogramData[0].channel).toEqual(assertItem.ResponseRegionHistogramData[2].channel);
+                expect(firstRegionHistogramData[0].progress).toEqual(assertItem.ResponseRegionHistogramData[2].progress);
+                expect(firstRegionHistogramData[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[2].regionId);
+                expect(firstRegionHistogramData[0].stokes).toEqual(assertItem.ResponseRegionHistogramData[2].stokes);
+                expect(firstRegionHistogramData[0].config.bounds).toEqual(assertItem.ResponseRegionHistogramData[2].config.bounds);
+                expect(firstRegionHistogramData[0].config.fixedBounds).toEqual(assertItem.ResponseRegionHistogramData[2].config.fixedBounds);
+                expect(firstRegionHistogramData[0].config.fixedNumBins).toEqual(assertItem.ResponseRegionHistogramData[2].config.fixedNumBins);
+                expect(firstRegionHistogramData[0].config.numBins).toEqual(assertItem.ResponseRegionHistogramData[2].config.numBins);
+                expect(firstRegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.ResponseRegionHistogramData[2].histograms.binWidth, assertItem.precisionDigits);
+                expect(firstRegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.ResponseRegionHistogramData[2].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(firstRegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.ResponseRegionHistogramData[2].histograms.mean, assertItem.precisionDigits);
+                expect(firstRegionHistogramData[0].histograms.numBins).toBeCloseTo(assertItem.ResponseRegionHistogramData[2].histograms.numBins, assertItem.precisionDigits);
+                expect(firstRegionHistogramData[0].histograms.stdDev).toBeCloseTo(assertItem.ResponseRegionHistogramData[2].histograms.stdDev, assertItem.precisionDigits);
+                expect(firstRegionHistogramData[0].histograms.bins).toEqual(assertItem.ResponseRegionHistogramData[2].histograms.bins);
+
+                let secondRegionHistogramData = RegionHistogramDataResponse.filter(data => data.histograms.numBins == 1049);
+                expect(secondRegionHistogramData[0].channel).toEqual(assertItem.ResponseRegionHistogramData[3].channel);
+                expect(secondRegionHistogramData[0].progress).toEqual(assertItem.ResponseRegionHistogramData[3].progress);
+                expect(secondRegionHistogramData[0].regionId).toEqual(assertItem.ResponseRegionHistogramData[3].regionId);
+                expect(secondRegionHistogramData[0].stokes).toEqual(assertItem.ResponseRegionHistogramData[3].stokes);
+                expect(secondRegionHistogramData[0].config.bounds).toEqual(assertItem.ResponseRegionHistogramData[3].config.bounds);
+                expect(secondRegionHistogramData[0].config.numBins).toEqual(assertItem.ResponseRegionHistogramData[3].config.numBins);
+                expect(secondRegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.binWidth, assertItem.precisionDigits);
+                expect(secondRegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(secondRegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.mean, assertItem.precisionDigits);
+                expect(secondRegionHistogramData[0].histograms.numBins).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.numBins, assertItem.precisionDigits);
+                expect(secondRegionHistogramData[0].histograms.stdDev).toBeCloseTo(assertItem.ResponseRegionHistogramData[3].histograms.stdDev, assertItem.precisionDigits);
+                expect(secondRegionHistogramData[0].histograms.bins.length).toEqual(assertItem.ResponseRegionHistogramData[3].histograms.numBins);
+
+                RasterTileDataResponse.map((data) => {
+                    expect(data.channel).toEqual(assertItem.setImageChannel.channel);
+                    expect(data.stokes).toEqual(assertItem.setImageChannel.stokes);
+                })
+            });
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/SET_HISTOGRAMCONFIG.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG.test.ts
@@ -6,7 +6,6 @@ import { take } from 'rxjs/operators';
 
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
-let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
 

--- a/src/test/SET_HISTOGRAMCONFIG.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG.test.ts
@@ -1,0 +1,66 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let saveSubdirectory = config.path.save;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesRequire: CARTA.IAddRequiredTiles;
+    precisionDigits: number;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements[];
+    setImageChannel: CARTA.ISetImageChannels;
+};
+
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    addTilesRequire:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    precisionDigits: 6,
+    setHistogramRequirements: [
+        {
+            fileId: 0,
+            regionId: -1,
+            histograms: [{channel: -1, numBins: 2, bounds: {min: -1, max: 0.1376738934777677}, coordinate: "Qz", fixedBounds: true, fixedNumBins: true}]
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "Qz", fixedBounds: false, fixedNumBins: false}]
+        }
+    ],
+    setImageChannel: 
+    {
+        fileId: 0,
+        channel: 3,
+        stokes: 1,
+        requiredTiles: {
+            fileId: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+            tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50348033, 50348035, 50348032],
+        },
+    }
+}

--- a/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
@@ -14,8 +14,10 @@ interface AssertItem {
     addTilesRequire: CARTA.IAddRequiredTiles;
     precisionDigits: number;
     setRegion: CARTA.ISetRegion;
-    setHistogramRequirements: CARTA.ISetHistogramRequirements[];
-    ResponseRegionHistogramData: CARTA.IRegionHistogramData[];
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    numBinsArray: number[];
+    ResponseRegionHistogramData: CARTA.IRegionHistogramData;
+    firstBinsArray: number[];
 };
 
 let assertItem: AssertItem = {
@@ -40,109 +42,64 @@ let assertItem: AssertItem = {
         regionId: -1,
         regionInfo: {
         regionType: CARTA.RegionType.POLYGON,
-            controlPoints: [{ x: 155, y: 552 }, { x: 134, y: 498 }, { x: 185, y: 509 }],
+            controlPoints: [
+                {x: 2846, y: 9898},
+                {x: 2362, y: 8506},
+                {x: 1756, y: 8597},
+                {x: 1938, y: 8112},
+                {x: 818, y: 7567},
+                {x: 1938, y: 6932},
+                {x: 939, y: 6266},
+                {x: 1696, y: 5781},
+                {x: 969, y: 4570},
+                {x: 2422, y: 5085},
+                {x: 2210, y: 3541},
+                {x: 2604, y: 3934},
+                {x: 2876, y: 2300},
+                {x: 3542, y: 3632},
+                {x: 4057, y: 2542},
+                {x: 4057, y: 3632},
+                {x: 5631, y: 2996},
+                {x: 4904, y: 3723},
+                {x: 6569, y: 4056},
+                {x: 5298, y: 4267},
+                {x: 6297, y: 5085},
+                {x: 5147, y: 5145},
+                {x: 7054, y: 6387},
+                {x: 6025, y: 6356},
+                {x: 6933, y: 8112},
+                {x: 5934, y: 7416},
+                {x: 6691, y: 9020},
+                {x: 5601, y: 8203},
+                {x: 5752, y: 9474},
+                {x: 3936, y: 7961},
+                {x: 5056, y: 9989},
+                {x: 3966, y: 8506},
+                {x: 3966, y: 10413},
+                {x: 3270, y: 8657},
+                {x: 3361, y: 10292},
+            ],
             rotation: 0.0,
         },
     },
-    setHistogramRequirements: [
-        // {
-        //     fileId: 0,
-        //     regionId: -1,
-        //     histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "z", fixedBounds: false, fixedNumBins: false}]
-        // },
-        // {
-        //     fileId: 0,
-        //     regionId: -1,
-        //     histograms: [{channel: -1, numBins: 2, bounds: {min: -1, max: 0.1376738934777677}, coordinate: "Qz", fixedBounds: true, fixedNumBins: true}]
-        // },
-        // {
-        //     fileId: 0,
-        //     regionId: -1,
-        //     histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "Qz", fixedBounds: false, fixedNumBins: false}]
-        // }
-    ],
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: 1,
+        histograms: [{channel: -1, numBins: 4779, bounds: {min: 0.01625968888401985, max: 78.3388689942658}, coordinate: "z", fixedBounds: true, fixedNumBins: true}]
+    },
+    numBinsArray: [4779, 4853, 5003, 5078, 5227, 5376, 5526, 5675, 5750, 5899, 5974, 6048],
     ResponseRegionHistogramData: 
-    [
-        // {
-        //     progress: 1,
-        //     regionId: -1,
-        //     config: 
-        //     {
-        //         bounds: {},
-        //         numBins: -1
-        //     },
-        //     histograms: 
-        //     {
-        //         binWidth: 0.0002482116688042879,
-        //         firstBinCenter: -0.12420587241649628,
-        //         mean: 0.000008066841056845398,
-        //         numBins: 1049,
-        //         stdDev: 0.014460244218400708,
-        //     }
-        // },
-        // {
-        //     progress: 1,
-        //     regionId: -1,
-        //     stokes: 1,
-        //     config: 
-        //     {
-        //         bounds:{min: -1, max: 0.1376738934777677},
-        //         fixedBounds: true, 
-        //         fixedNumBins: true, 
-        //         numBins: 2
-        //     },
-        //     histograms: 
-        //     {
-        //         binWidth: 0.5688369274139404,
-        //         bins: [0, 736448],
-        //         firstBinCenter: -0.7155815362930298,
-        //         mean: -0.0000026881257400475778,
-        //         numBins: 2,
-        //         stdDev: 0.0142919735819505,
-        //     }
-        // },
-        // {
-        //     channel: 3,
-        //     progress: 1,
-        //     regionId: -1,
-        //     stokes: 1,
-        //     config: 
-        //     {
-        //         bounds:{min: -1, max: 0.1376738934777677},
-        //         fixedBounds: true, 
-        //         fixedNumBins: true, 
-        //         numBins: 2
-        //     },
-        //     histograms: 
-        //     {
-        //         binWidth: 0.5688369274139404,
-        //         bins: [0, 736705],
-        //         firstBinCenter: -0.7155815362930298,
-        //         mean: 0.000002222024835655828,
-        //         numBins: 2,
-        //         stdDev: 0.002096762523721388,
-        //     }
-        // },
-        // {
-        //     channel: 3,
-        //     progress: 1,
-        //     regionId: -1,
-        //     stokes: 1,
-        //     config: 
-        //     {
-        //         bounds:{},
-        //         numBins: -1
-        //     },
-        //     histograms: 
-        //     {
-        //         binWidth: 0.00003724902853718959,
-        //         firstBinCenter: -0.016793109476566315,
-        //         mean: 0.000002222024835655828,
-        //         numBins: 1049,
-        //         stdDev: 0.002096762523721388,
-        //     }
-        // }
-    ]
+    {
+        progress: 1,
+        regionId: 1,
+        config: 
+        {
+            bounds: {min: 0.01625968888401985, max: 78.3388689942658},
+            fixedBounds: true,
+            fixedNumBins: true
+        },
+    },
+    firstBinsArray: [1738900, 1703245, 1634588, 1601625, 1539657, 1481300, 1425994, 1373866, 1348887, 1300739, 1277511, 1255213],
 }
 
 let basepath: string;
@@ -177,6 +134,13 @@ describe("Testing the large image with multi-polygon region and set_histogram_re
                 
                 expect(receiveNumber2 - receiveNumber1).toEqual(3);
             }, openFileTimeout);
+
+            test(`(Step 1) Set a many points polygon region:`, async () => {
+                let SetRegionAck: CARTA.ISetRegionAck;
+                SetRegionAck = await msgController.setRegion(assertItem.setRegion.fileId, assertItem.setRegion.regionId, assertItem.setRegion.regionInfo);
+                expect(SetRegionAck.success).toEqual(true);
+                expect(SetRegionAck.regionId).toEqual(1);
+            });
 
         });
 

--- a/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
@@ -175,6 +175,17 @@ describe("Testing the large image with multi-polygon region and set_histogram_re
 
             test(`(Step 3) Check the receiveing RegionHistogramData * 12 `, () => {
                 expect(regionHistogramDataResponse.length).toEqual(assertItem.numBinsArray.length);
+                regionHistogramDataResponse.map((RegionHistogramData,index) => {
+                    expect(RegionHistogramData.progress).toEqual(assertItem.ResponseRegionHistogramData.progress);
+                    expect(RegionHistogramData.regionId).toEqual(assertItem.ResponseRegionHistogramData.regionId);
+                    expect(RegionHistogramData.config.bounds.min).toEqual(assertItem.ResponseRegionHistogramData.config.bounds.min);
+                    expect(RegionHistogramData.config.bounds.max).toEqual(assertItem.ResponseRegionHistogramData.config.bounds.max);
+                    expect(RegionHistogramData.config.fixedBounds).toEqual(assertItem.ResponseRegionHistogramData.config.fixedBounds);
+                    expect(RegionHistogramData.config.fixedNumBins).toEqual(assertItem.ResponseRegionHistogramData.config.fixedNumBins);
+                    expect(RegionHistogramData.config.numBins).toEqual(assertItem.numBinsArray[index]);
+                    expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.numBinsArray[index]);
+                    expect(RegionHistogramData.histograms.bins[0]).toEqual(assertItem.firstBinsArray[index]);
+                })
             })
 
         });

--- a/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
@@ -13,8 +13,8 @@ interface AssertItem {
     openFile: CARTA.IOpenFile;
     addTilesRequire: CARTA.IAddRequiredTiles;
     precisionDigits: number;
+    setRegion: CARTA.ISetRegion;
     setHistogramRequirements: CARTA.ISetHistogramRequirements[];
-    setImageChannel: CARTA.ISetImageChannels;
     ResponseRegionHistogramData: CARTA.IRegionHistogramData[];
 };
 
@@ -22,7 +22,7 @@ let assertItem: AssertItem = {
     openFile:
     {
         directory: testSubdirectory,
-        file: "HH211_IQU.fits",
+        file: "h_m51_b_s05_drz_sci.fits",
         fileId: 0,
         hdu: "0",
         renderMode: CARTA.RenderMode.RASTER,
@@ -35,115 +35,151 @@ let assertItem: AssertItem = {
         compressionType: CARTA.CompressionType.ZFP,
     },
     precisionDigits: 6,
-    setHistogramRequirements: [
-        {
-            fileId: 0,
-            regionId: -1,
-            histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "z", fixedBounds: false, fixedNumBins: false}]
-        },
-        {
-            fileId: 0,
-            regionId: -1,
-            histograms: [{channel: -1, numBins: 2, bounds: {min: -1, max: 0.1376738934777677}, coordinate: "Qz", fixedBounds: true, fixedNumBins: true}]
-        },
-        {
-            fileId: 0,
-            regionId: -1,
-            histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "Qz", fixedBounds: false, fixedNumBins: false}]
-        }
-    ],
-    setImageChannel: 
-    {
+    setRegion: {
         fileId: 0,
-        channel: 3,
-        stokes: 1,
-        requiredTiles: {
-            fileId: 0,
-            compressionType: CARTA.CompressionType.ZFP,
-            compressionQuality: 11,
-            tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50348033, 50348035, 50348032],
+        regionId: -1,
+        regionInfo: {
+        regionType: CARTA.RegionType.POLYGON,
+            controlPoints: [{ x: 155, y: 552 }, { x: 134, y: 498 }, { x: 185, y: 509 }],
+            rotation: 0.0,
         },
     },
+    setHistogramRequirements: [
+        // {
+        //     fileId: 0,
+        //     regionId: -1,
+        //     histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "z", fixedBounds: false, fixedNumBins: false}]
+        // },
+        // {
+        //     fileId: 0,
+        //     regionId: -1,
+        //     histograms: [{channel: -1, numBins: 2, bounds: {min: -1, max: 0.1376738934777677}, coordinate: "Qz", fixedBounds: true, fixedNumBins: true}]
+        // },
+        // {
+        //     fileId: 0,
+        //     regionId: -1,
+        //     histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "Qz", fixedBounds: false, fixedNumBins: false}]
+        // }
+    ],
     ResponseRegionHistogramData: 
     [
-        {
-            progress: 1,
-            regionId: -1,
-            config: 
-            {
-                bounds: {},
-                numBins: -1
-            },
-            histograms: 
-            {
-                binWidth: 0.0002482116688042879,
-                firstBinCenter: -0.12420587241649628,
-                mean: 0.000008066841056845398,
-                numBins: 1049,
-                stdDev: 0.014460244218400708,
-            }
-        },
-        {
-            progress: 1,
-            regionId: -1,
-            stokes: 1,
-            config: 
-            {
-                bounds:{min: -1, max: 0.1376738934777677},
-                fixedBounds: true, 
-                fixedNumBins: true, 
-                numBins: 2
-            },
-            histograms: 
-            {
-                binWidth: 0.5688369274139404,
-                bins: [0, 736448],
-                firstBinCenter: -0.7155815362930298,
-                mean: -0.0000026881257400475778,
-                numBins: 2,
-                stdDev: 0.0142919735819505,
-            }
-        },
-        {
-            channel: 3,
-            progress: 1,
-            regionId: -1,
-            stokes: 1,
-            config: 
-            {
-                bounds:{min: -1, max: 0.1376738934777677},
-                fixedBounds: true, 
-                fixedNumBins: true, 
-                numBins: 2
-            },
-            histograms: 
-            {
-                binWidth: 0.5688369274139404,
-                bins: [0, 736705],
-                firstBinCenter: -0.7155815362930298,
-                mean: 0.000002222024835655828,
-                numBins: 2,
-                stdDev: 0.002096762523721388,
-            }
-        },
-        {
-            channel: 3,
-            progress: 1,
-            regionId: -1,
-            stokes: 1,
-            config: 
-            {
-                bounds:{},
-                numBins: -1
-            },
-            histograms: 
-            {
-                binWidth: 0.00003724902853718959,
-                firstBinCenter: -0.016793109476566315,
-                mean: 0.000002222024835655828,
-                numBins: 1049,
-                stdDev: 0.002096762523721388,
-            }
-        }
+        // {
+        //     progress: 1,
+        //     regionId: -1,
+        //     config: 
+        //     {
+        //         bounds: {},
+        //         numBins: -1
+        //     },
+        //     histograms: 
+        //     {
+        //         binWidth: 0.0002482116688042879,
+        //         firstBinCenter: -0.12420587241649628,
+        //         mean: 0.000008066841056845398,
+        //         numBins: 1049,
+        //         stdDev: 0.014460244218400708,
+        //     }
+        // },
+        // {
+        //     progress: 1,
+        //     regionId: -1,
+        //     stokes: 1,
+        //     config: 
+        //     {
+        //         bounds:{min: -1, max: 0.1376738934777677},
+        //         fixedBounds: true, 
+        //         fixedNumBins: true, 
+        //         numBins: 2
+        //     },
+        //     histograms: 
+        //     {
+        //         binWidth: 0.5688369274139404,
+        //         bins: [0, 736448],
+        //         firstBinCenter: -0.7155815362930298,
+        //         mean: -0.0000026881257400475778,
+        //         numBins: 2,
+        //         stdDev: 0.0142919735819505,
+        //     }
+        // },
+        // {
+        //     channel: 3,
+        //     progress: 1,
+        //     regionId: -1,
+        //     stokes: 1,
+        //     config: 
+        //     {
+        //         bounds:{min: -1, max: 0.1376738934777677},
+        //         fixedBounds: true, 
+        //         fixedNumBins: true, 
+        //         numBins: 2
+        //     },
+        //     histograms: 
+        //     {
+        //         binWidth: 0.5688369274139404,
+        //         bins: [0, 736705],
+        //         firstBinCenter: -0.7155815362930298,
+        //         mean: 0.000002222024835655828,
+        //         numBins: 2,
+        //         stdDev: 0.002096762523721388,
+        //     }
+        // },
+        // {
+        //     channel: 3,
+        //     progress: 1,
+        //     regionId: -1,
+        //     stokes: 1,
+        //     config: 
+        //     {
+        //         bounds:{},
+        //         numBins: -1
+        //     },
+        //     histograms: 
+        //     {
+        //         binWidth: 0.00003724902853718959,
+        //         firstBinCenter: -0.016793109476566315,
+        //         mean: 0.000002222024835655828,
+        //         numBins: 1049,
+        //         stdDev: 0.002096762523721388,
+        //     }
+        // }
     ]
 }
+
+let basepath: string;
+describe("Testing the large image with multi-polygon region and set_histogram_requirement, let the region_histogram_data in queue:", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        afterAll(() => msgController.closeConnection());
+
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);;
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                let receiveNumber1 = msgController.messageReceiving()
+                msgController.addRequiredTiles(assertItem.addTilesRequire);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                let receiveNumber2 = msgController.messageReceiving();
+                
+                expect(receiveNumber2 - receiveNumber1).toEqual(3);
+            }, openFileTimeout);
+
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
@@ -173,7 +173,7 @@ describe("Testing the large image with multi-polygon region and set_histogram_re
                 regionHistogramDataResponse = await regionHistogramDataPromise;
             }, dragHistogramNumberBins);
 
-            test(`(Step 3) Check the receiveing RegionHistogramData * 12 `, () => {
+            test(`(Step 3) Check the receiving RegionHistogramData * 12 `, () => {
                 expect(regionHistogramDataResponse.length).toEqual(assertItem.numBinsArray.length);
                 regionHistogramDataResponse.map((RegionHistogramData,index) => {
                     expect(RegionHistogramData.progress).toEqual(assertItem.ResponseRegionHistogramData.progress);
@@ -182,9 +182,9 @@ describe("Testing the large image with multi-polygon region and set_histogram_re
                     expect(RegionHistogramData.config.bounds.max).toEqual(assertItem.ResponseRegionHistogramData.config.bounds.max);
                     expect(RegionHistogramData.config.fixedBounds).toEqual(assertItem.ResponseRegionHistogramData.config.fixedBounds);
                     expect(RegionHistogramData.config.fixedNumBins).toEqual(assertItem.ResponseRegionHistogramData.config.fixedNumBins);
-                    expect(RegionHistogramData.config.numBins).toEqual(assertItem.numBinsArray[index]);
-                    expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.numBinsArray[index]);
-                    expect(RegionHistogramData.histograms.bins[0]).toEqual(assertItem.firstBinsArray[index]);
+                    expect(assertItem.numBinsArray).toContainEqual(RegionHistogramData.config.numBins);
+                    expect(assertItem.numBinsArray).toContainEqual(RegionHistogramData.histograms.numBins);
+                    expect(assertItem.firstBinsArray).toContainEqual(RegionHistogramData.histograms.bins[0]);
                 })
             })
 

--- a/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
@@ -174,7 +174,7 @@ describe("Testing the large image with multi-polygon region and set_histogram_re
             }, dragHistogramNumberBins);
 
             test(`(Step 3) Check the receiveing RegionHistogramData * 12 `, () => {
-                console.log(regionHistogramDataResponse);
+                expect(regionHistogramDataResponse.length).toEqual(assertItem.numBinsArray.length);
             })
 
         });

--- a/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
+++ b/src/test/SET_HISTOGRAMCONFIG_QUEUE.test.ts
@@ -1,0 +1,149 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    addTilesRequire: CARTA.IAddRequiredTiles;
+    precisionDigits: number;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements[];
+    setImageChannel: CARTA.ISetImageChannels;
+    ResponseRegionHistogramData: CARTA.IRegionHistogramData[];
+};
+
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "HH211_IQU.fits",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesRequire:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    precisionDigits: 6,
+    setHistogramRequirements: [
+        {
+            fileId: 0,
+            regionId: -1,
+            histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "z", fixedBounds: false, fixedNumBins: false}]
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            histograms: [{channel: -1, numBins: 2, bounds: {min: -1, max: 0.1376738934777677}, coordinate: "Qz", fixedBounds: true, fixedNumBins: true}]
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            histograms: [{channel: -1, numBins: -1, bounds: {min: 0, max: 0}, coordinate: "Qz", fixedBounds: false, fixedNumBins: false}]
+        }
+    ],
+    setImageChannel: 
+    {
+        fileId: 0,
+        channel: 3,
+        stokes: 1,
+        requiredTiles: {
+            fileId: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+            tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50348033, 50348035, 50348032],
+        },
+    },
+    ResponseRegionHistogramData: 
+    [
+        {
+            progress: 1,
+            regionId: -1,
+            config: 
+            {
+                bounds: {},
+                numBins: -1
+            },
+            histograms: 
+            {
+                binWidth: 0.0002482116688042879,
+                firstBinCenter: -0.12420587241649628,
+                mean: 0.000008066841056845398,
+                numBins: 1049,
+                stdDev: 0.014460244218400708,
+            }
+        },
+        {
+            progress: 1,
+            regionId: -1,
+            stokes: 1,
+            config: 
+            {
+                bounds:{min: -1, max: 0.1376738934777677},
+                fixedBounds: true, 
+                fixedNumBins: true, 
+                numBins: 2
+            },
+            histograms: 
+            {
+                binWidth: 0.5688369274139404,
+                bins: [0, 736448],
+                firstBinCenter: -0.7155815362930298,
+                mean: -0.0000026881257400475778,
+                numBins: 2,
+                stdDev: 0.0142919735819505,
+            }
+        },
+        {
+            channel: 3,
+            progress: 1,
+            regionId: -1,
+            stokes: 1,
+            config: 
+            {
+                bounds:{min: -1, max: 0.1376738934777677},
+                fixedBounds: true, 
+                fixedNumBins: true, 
+                numBins: 2
+            },
+            histograms: 
+            {
+                binWidth: 0.5688369274139404,
+                bins: [0, 736705],
+                firstBinCenter: -0.7155815362930298,
+                mean: 0.000002222024835655828,
+                numBins: 2,
+                stdDev: 0.002096762523721388,
+            }
+        },
+        {
+            channel: 3,
+            progress: 1,
+            regionId: -1,
+            stokes: 1,
+            config: 
+            {
+                bounds:{},
+                numBins: -1
+            },
+            histograms: 
+            {
+                binWidth: 0.00003724902853718959,
+                firstBinCenter: -0.016793109476566315,
+                mean: 0.000002222024835655828,
+                numBins: 1049,
+                stdDev: 0.002096762523721388,
+            }
+        }
+    ]
+}

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -51,13 +51,15 @@
         "openLargeFiles": 60000,
         "pvRequest": 60000,
         "imageFitting": 100000,
-        "vectorOverlay": 6000
+        "vectorOverlay": 6000,
+        "dragManyNumberBins": 10000
     },
     "repeat": {
         "concurrent": 10,
         "cursor": 10,
         "image": 10,
-        "animation": 100
+        "animation": 100,
+        "setHistogram": 200
     },
     "log": {
         "error": false,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -59,7 +59,7 @@
         "cursor": 10,
         "image": 10,
         "animation": 100,
-        "setHistogram": 200
+        "setHistogram": 500
     },
     "log": {
         "error": false,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -52,14 +52,14 @@
         "pvRequest": 60000,
         "imageFitting": 100000,
         "vectorOverlay": 6000,
-        "dragManyNumberBins": 10000
+        "dragManyNumberBins": 100000
     },
     "repeat": {
         "concurrent": 10,
         "cursor": 10,
         "image": 10,
         "animation": 100,
-        "setHistogram": 500
+        "setHistogram": 200
     },
     "log": {
         "error": false,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -19,7 +19,7 @@
     "timeout": {
         "connection": 1100,
         "listFile": 1200,
-        "openFile": 6000,
+        "openFile": 8000,
         "readFile": 6000,
         "saveFile": 3000,
         "readLargeImage": 90000,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -52,6 +52,7 @@
         "pvRequest": 60000,
         "imageFitting": 100000,
         "vectorOverlay": 6000,
+        "firstHistogramCancellation": 30000,
         "dragManyNumberBins": 100000
     },
     "repeat": {


### PR DESCRIPTION
**Description**

Finish the Issue #15 , adding two new tests to test the new setHistogramRequirement protobuf:
SET_HISTOGRAMCONFIG.test.t
SET_HISTOGRAMCONFIG_QUEUE.test.t

The detail documentation is [here](https://docs.google.com/document/d/1F74bBEGnTsDnYlyr5_wmh4Y1dP7yabKV490aPhBdqus/edit#heading=h.o37maj7svoph)

So far, I have tested all files are passed with the current dev backend on MacOS 11.

**Checklist**

For the pull request:
- [x] ~~The Document unchange~~ / Need update the Document
