### PR TITLE
updating dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,17 @@
   "dependencies": {
     "react-scripts": "^5.0.1",
     "ws": "^8.13.0"
-},
+  },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.2",
-    "protobufjs": "6.9.0",
-    "typescript": "^4.1.5",
+    "jest-watch-typeahead": "^0.6.5",
     "mobx": "^6.9.0",
-    "rxjs": "^7.8.1"
-},
+    "protobufjs": "6.9.0",
+    "rxjs": "^7.8.1",
+    "typescript": "^4.1.5"
+  },
   "scripts": {
     "test": "react-scripts test --env=node --maxWorkers=1 --verbose --no-cache --forceExit"
   },

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "react-scripts": "^3.4.4",
-    "ws": "^7.4.2"
+    "react-scripts": "^5.0.1",
+    "ws": "^8.13.0"
 },
   "devDependencies": {
-    "@types/jest": "^23.3.14",
-    "@types/node": "^10.17.51",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.3.2",
     "protobufjs": "6.9.0",
-    "typescript": "^3.9.7",
-    "mobx": "^6.1.7",
-    "rxjs": "^7.2.0"
+    "typescript": "^4.1.5",
+    "mobx": "^6.9.0",
+    "rxjs": "^7.8.1"
 },
   "scripts": {
     "test": "react-scripts test --env=node --maxWorkers=1 --verbose --no-cache --forceExit"

--- a/src/test/ANIMATOR_CONTOUR.test.ts
+++ b/src/test/ANIMATOR_CONTOUR.test.ts
@@ -263,7 +263,7 @@ describe("ANIMATOR_CONTOUR: Testing animation playback with contour lines", () =
             }, playAnimatorTimeout);
 
             test(`Received RasterTileData channels should be in sequence`, async () => {
-                console.warn(`(Step 1) Sequent channel index: ${RasterTileSequence}`);
+                console.log(`(Step 1) Sequent channel index: ${RasterTileSequence}`);
                 RasterTileSequence.map((id, index) => {
                     let channelId = (index + assertItem.startAnimation[0].startFrame.channel + assertItem.startAnimation[0].deltaFrame.channel) - 1.;
                     expect(id).toEqual(channelId);
@@ -408,7 +408,7 @@ describe("ANIMATOR_CONTOUR: Testing animation playback with contour lines", () =
             }, playAnimatorTimeout);
 
             test(`Received RasterTileData channels should be in sequence`, async () => {
-                console.warn(`(Step 2) Sequent channel index: ${RasterTileSequence}`);
+                console.log(`(Step 2) Sequent channel index: ${RasterTileSequence}`);
                 RasterTileSequence.map((id, index) => {
                     let channelId = -index + assertItem.startAnimation[1].startFrame.channel - 1;
                     expect(id).toEqual(channelId);

--- a/src/test/ANIMATOR_PLAYBACK.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK.test.ts
@@ -360,7 +360,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async() => {
-                console.warn(`(Step 2) Sequent channel index: ${sequence}`);
+                console.log(`(Step 2) Sequent channel index: ${sequence}`);
                 assertItem.numArray2.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })
@@ -429,7 +429,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async() => {
-                console.warn(`(Step 3) Sequent channel index: ${sequence}`);
+                console.log(`(Step 3) Sequent channel index: ${sequence}`);
                 assertItem.numArray3.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })
@@ -499,7 +499,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async() => {
-                console.warn(`(Step 4) Sequent channel index: ${sequence}`);
+                console.log(`(Step 4) Sequent channel index: ${sequence}`);
                 assertItem.numArray4.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })
@@ -561,7 +561,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence and then reverse:`, async () => {
-                console.warn(`(Step 5) Channel index in roundtrip: ${sequence}`);
+                console.log(`(Step 5) Channel index in roundtrip: ${sequence}`);
                 assertItem.numArray5.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })
@@ -626,7 +626,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
-                console.warn(`(Step 6) Backward channel index with method 1: ${sequence}`);
+                console.log(`(Step 6) Backward channel index with method 1: ${sequence}`);
                 assertItem.numArray6.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })
@@ -691,7 +691,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
-                console.warn(`(Step 6) Backward channel index with method 2: ${sequence}`);
+                console.log(`(Step 6) Backward channel index with method 2: ${sequence}`);
                 assertItem.numArray6.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })
@@ -747,7 +747,7 @@ describe("PERF_ANIMATION_PLAYBACK",() => {
             }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
-                console.warn(`(Step 7) Blink channel index: ${sequence}`);
+                console.log(`(Step 7) Blink channel index: ${sequence}`);
                 assertItem.numArray7.map((value,index) => {
                     expect(sequence[index]).toEqual(value)
                 })

--- a/src/test/ANIMATOR_SWAPPED_IMAGES.test.ts
+++ b/src/test/ANIMATOR_SWAPPED_IMAGES.test.ts
@@ -247,7 +247,7 @@ describe("ANIMATOR_SWAPPED_IMAGES test: Testing the channel and stokes animation
                     for (let i=0; i<sequence.length; i++) {
                         expect(RegionHistogramData[i].channel).toEqual(sequence[i])
                     }
-                    console.warn(`(Step 3) Sequent channel index: ${sequence}`);
+                    console.log(`(Step 3) Sequent channel index: ${sequence}`);
                 }, playAnimatorTimeout);
             })
 
@@ -295,7 +295,7 @@ describe("ANIMATOR_SWAPPED_IMAGES test: Testing the channel and stokes animation
                     for (let i=0; i<StokesSequence.length; i++) {
                         expect(RegionHistogramData[i].stokes).toEqual(StokesSequence[i])
                     }
-                    console.warn(`(Step 4) Sequent Stokes index: ${StokesSequence}`);
+                    console.log(`(Step 4) Sequent Stokes index: ${StokesSequence}`);
                 }, playAnimatorTimeout);
             });
         });

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -252,7 +252,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                     importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId )
                     importRegionAckProperties = Object.keys(importRegionAck.regions);
                     if (importRegionAck.message != '') {
-                        console.warn(importRegionAck.message);
+                        console.log(importRegionAck.message);
                     }
                 }, importTimeout);
     
@@ -325,7 +325,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
 
                         importRegionAckProperties = Object.keys(importRegionAck.regions);
                         if (importRegionAck.message != '') {
-                            console.warn(importRegionAck.message);
+                            console.log(importRegionAck.message);
                         }
                     }, importTimeout);
     

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -244,7 +244,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                     importRegionAck = await msgController.importRegion(assertItem.importRegion.directory ,assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId )
                     importRegionAckProperties = Object.keys(importRegionAck.regions);
                     if (importRegionAck.message != '') {
-                        console.warn(importRegionAck.message);
+                        console.log(importRegionAck.message);
                     }
                 }, importTimeout);
     
@@ -306,7 +306,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                         
                         importRegionAckProperties = Object.keys(importRegionAck.regions);
                         if (importRegionAck.message != '') {
-                            console.warn(importRegionAck.message);
+                            console.log(importRegionAck.message);
                         }
                     }, importTimeout);
     

--- a/src/test/IMAGE_FITTING_CANCEL.test.ts
+++ b/src/test/IMAGE_FITTING_CANCEL.test.ts
@@ -136,7 +136,7 @@ describe("IMAGE_FITTING_CANCEL test: Testing cancel function in image fitting.",
                         msgController.fittingProgressStream.subscribe({
                             next: (data) => {
                                 count++;
-                                console.warn('Image Fitting progress :', data.progress);
+                                console.log('Image Fitting progress :', data.progress);
                                 imageFittingProgressArray.push(data)
                                 if (count == 10) {
                                     msgController.cancelRequestingFitting(assertItem.stopFittingRequest.fileId)

--- a/src/test/MessageController-concurrent.ts
+++ b/src/test/MessageController-concurrent.ts
@@ -821,7 +821,7 @@ export class BackendService {
         const eventId = eventHeader32[0];
 
         if (eventIcdVersion !== BackendService.IcdVersion) {
-            console.warn(`Server event has ICD version ${eventIcdVersion}, which differs from frontend version ${BackendService.IcdVersion}. Errors may occur`);
+            console.log(`Server event has ICD version ${eventIcdVersion}, which differs from frontend version ${BackendService.IcdVersion}. Errors may occur`);
         }
         try {
             const decoderEntry = this.decoderMap.get(eventType);

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -888,7 +888,7 @@ export class MessageController {
         const eventId = eventHeader32[0];
 
         if (eventIcdVersion !== MessageController.IcdVersion) {
-            console.warn(`Server event has ICD version ${eventIcdVersion}, which differs from frontend version ${MessageController.IcdVersion}. Errors may occur`);
+            console.log(`Server event has ICD version ${eventIcdVersion}, which differs from frontend version ${MessageController.IcdVersion}. Errors may occur`);
         }
         try {
             const decoderEntry = this.decoderMap.get(eventType);

--- a/src/test/PV_GENERATOR_CANCEL.test.ts
+++ b/src/test/PV_GENERATOR_CANCEL.test.ts
@@ -159,7 +159,7 @@ describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
                     msgController.pvProgressStream.subscribe({
                         next: (data) => {
                             count++;
-                            console.warn('request ' + assertItem.openFile.file + ' PV response progress :', data.progress);
+                            console.log('request ' + assertItem.openFile.file + ' PV response progress :', data.progress);
                             pvProgressArray.push(data)
                             if (count == 3) {
                                 msgController.cancelRequestingPV(assertItem.setPVRequest.fileId);

--- a/src/test/RESUME_CATALOG.test.ts
+++ b/src/test/RESUME_CATALOG.test.ts
@@ -80,7 +80,7 @@ describe("RESUME CONTOUR: Test to resume contour lines", () => {
             let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
             expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
             if (ResumeAck.message) {
-                console.warn(`RESUME_SESSION_ACK error message: 
+                console.log(`RESUME_SESSION_ACK error message: 
                         ${ResumeAck.message}`);
             }
         }, resumeTimeout);

--- a/src/test/RESUME_CONTOUR.test.ts
+++ b/src/test/RESUME_CONTOUR.test.ts
@@ -92,7 +92,7 @@ describe("RESUME CONTOUR: Test to resume contour lines", () => {
             let regionHistogramDataResponse = await regionHistogramDataPromise;
             expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
             if (ResumeAck.message) {
-                console.warn(`RESUME_SESSION_ACK error message: 
+                console.log(`RESUME_SESSION_ACK error message: 
                         ${ResumeAck.message}`);
             }
         }, resumeTimeout);

--- a/src/test/RESUME_IMAGE.test.ts
+++ b/src/test/RESUME_IMAGE.test.ts
@@ -91,7 +91,7 @@ describe("RESUME IMAGE: Test to resume images", () => {
             let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
             expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
             if (ResumeAck.message) {
-                console.warn(`RESUME_SESSION_ACK error message: 
+                console.log(`RESUME_SESSION_ACK error message: 
                         ${ResumeAck.message}`);
             }
         }, resumeTimeout);

--- a/src/test/RESUME_REGION.test.ts
+++ b/src/test/RESUME_REGION.test.ts
@@ -115,7 +115,7 @@ describe("RESUME REGION: Test to resume regions", () => {
             let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
             expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
             if (ResumeAck.message) {
-                console.warn(`RESUME_SESSION_ACK error message: 
+                console.log(`RESUME_SESSION_ACK error message: 
                         ${ResumeAck.message}`);
             }
         }, resumeTimeout);


### PR DESCRIPTION
**Description**

This should address issue #28  

I have updated the other dependencies too to the latest versions except for `protobufjs` and `typescript`.
When I tried to update protobufjs from 6.9.0 to 7.2.4 and typescript from 4.1.5 to 5.1.5, it didn't work.
I guess they need to be the same versions as used by the carta-frontend?

@acdo2002 are you OK with the dependencies getting updated?

**Checklist**

For the pull request:
- [x] The Document unchange 