### PR TITLE
Adding null into IBackendResponse in MessageController*

### DIFF
--- a/src/performance/MessageController.ts
+++ b/src/performance/MessageController.ts
@@ -15,8 +15,8 @@ export const INVALID_ANIMATION_ID = -1;
 type HandlerFunction = (eventId: number, parsedMessage: any) => void;
 
 interface IBackendResponse {
-    success?: boolean;
-    message?: string;
+    success?: boolean | null;
+    message?: string | null;
 }
 
 // Deferred class adapted from https://stackoverflow.com/a/58610922/1727322

--- a/src/test/MessageController-concurrent.ts
+++ b/src/test/MessageController-concurrent.ts
@@ -14,8 +14,8 @@ export const INVALID_ANIMATION_ID = -1;
 type HandlerFunction = (eventId: number, parsedMessage: any) => void;
 
 interface IBackendResponse {
-    success?: boolean;
-    message?: string;
+    success?: boolean | null;
+    message?: string | null;
 }
 
 // Deferred class adapted from https://stackoverflow.com/a/58610922/1727322

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -15,8 +15,8 @@ export const INVALID_ANIMATION_ID = -1;
 type HandlerFunction = (eventId: number, parsedMessage: any) => void;
 
 interface IBackendResponse {
-    success?: boolean;
-    message?: string;
+    success?: boolean | null;
+    message?: string | null;
 }
 
 // Deferred class adapted from https://stackoverflow.com/a/58610922/1727322


### PR DESCRIPTION
**Description**

Because the frontend [PR](https://github.com/CARTAvis/carta-frontend/pull/2344) has changed the BackendService.ts, the corresponding MessageController* in the ICD-RxJS also needs update.

**Checklist**

For the pull request:
- [x] The Document unchange / ~~Need update the Document~~
