### PR TITLE
Fixed the current building issue of centOS7 in the CI/CD

### DIFF
--- a/.github/workflows/all_stages_icd_tests.yml
+++ b/.github/workflows/all_stages_icd_tests.yml
@@ -92,8 +92,8 @@ jobs:
           SRC_DIR=$GITHUB_WORKSPACE/source
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          cd source ; git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            git submodule update --init --recursive && \
             ls && pwd && \
             cd $BUILD_DIR && \
             ls && pwd && \
@@ -192,10 +192,12 @@ jobs:
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
           cp -r $ICD_DIR $BUILD_DIR
+          cd $BUILD_DIR/ICD-RxJS
+          git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
             ls && pwd && \
-            git submodule init && git submodule update && npm install && \
+            npm install && \
             cd protobuf && \
             ./build_proto.sh && \
             cd ../src/test && \

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -115,8 +115,8 @@ jobs:
           SRC_DIR=$GITHUB_WORKSPACE/source
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          cd source ; git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            git submodule update --init --recursive && \
             ls && pwd && \
             cd $BUILD_DIR && \
             ls && pwd && \
@@ -209,10 +209,12 @@ jobs:
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
           cp -r $ICD_DIR $BUILD_DIR
+          cd $BUILD_DIR/ICD-RxJS
+          git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
             ls && pwd && \
-            git submodule init && git submodule update && npm install && \
+            npm install && \
             cd protobuf && \
             ./build_proto.sh && \
             cd ../src/test && \

--- a/.github/workflows/single_stage_icd_tests.yml
+++ b/.github/workflows/single_stage_icd_tests.yml
@@ -111,8 +111,8 @@ jobs:
           SRC_DIR=$GITHUB_WORKSPACE/source
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          cd source ; git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            git submodule update --init --recursive && \
             ls && pwd && \
             cd $BUILD_DIR && \
             ls && pwd && \
@@ -211,10 +211,12 @@ jobs:
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
           cp -r $ICD_DIR $BUILD_DIR
+          cd $BUILD_DIR/ICD-RxJS
+          git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
             ls && pwd && \
-            git submodule init && git submodule update && npm install && \
+            npm install && \
             cd protobuf && \
             ./build_proto.sh && \
             cd ../src/test && \


### PR DESCRIPTION
**Description**

Found this issue in the CentOS7 ([link](https://github.com/CARTAvis/ICD-RxJS/actions/runs/8836473358/job/24263117799))
`fatal: Expected git repo version <= 0, found 1`
It is because the git version of centOS7 is not working to github action runner (from 2.315.0 -> 2.316.0).
I try to put `git submodule update --init --recursive` into the previous step as well as go the the source folder to download the latest version of repository.

After this change, this branch has passed in the action runner ([link](https://github.com/CARTAvis/ICD-RxJS/actions/runs/8860914721))

**Checklist**

For the pull request:
- [x] The Document unchange / ~~Need update the Document~~
