### PR TITLE
Fixed the protobuf update induced failure

### DIFF
--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -132,10 +132,10 @@ export class MessageController {
             [CARTA.EventType.REGION_FILE_INFO_RESPONSE, {messageClass: CARTA.RegionFileInfoResponse, handler: this.onDeferredResponse}],
             [CARTA.EventType.CATALOG_FILE_INFO_RESPONSE, {messageClass: CARTA.CatalogFileInfoResponse, handler: this.onDeferredResponse}],
             [CARTA.EventType.OPEN_FILE_ACK, {messageClass: CARTA.OpenFileAck, handler: this.onDeferredResponse}],
-            [CARTA.EventType.SAVE_FILE_ACK, {messageClass: CARTA.SaveFileAck, handler: this.onDeferredResponse}],
+            [CARTA.EventType.SAVE_FILE_ACK, {messageClass: CARTA.SaveFileAck, handler: this.onSaveFileAndRegionAck}],
             [CARTA.EventType.OPEN_CATALOG_FILE_ACK, {messageClass: CARTA.OpenCatalogFileAck, handler: this.onDeferredResponse}],
             [CARTA.EventType.IMPORT_REGION_ACK, {messageClass: CARTA.ImportRegionAck, handler: this.onDeferredResponse}],
-            [CARTA.EventType.EXPORT_REGION_ACK, {messageClass: CARTA.ExportRegionAck, handler: this.onDeferredResponse}],
+            [CARTA.EventType.EXPORT_REGION_ACK, {messageClass: CARTA.ExportRegionAck, handler: this.onSaveFileAndRegionAck}],
             [CARTA.EventType.SET_REGION_ACK, {messageClass: CARTA.SetRegionAck, handler: this.onDeferredResponse}],
             [CARTA.EventType.RESUME_SESSION_ACK, {messageClass: CARTA.ResumeSessionAck, handler: this.onDeferredResponse}],
             [CARTA.EventType.START_ANIMATION_ACK, {messageClass: CARTA.StartAnimationAck, handler: this.onStartAnimationAck}],
@@ -364,11 +364,11 @@ export class MessageController {
         }
     }
 
-    async exportRegion(directory: string, file: string, type: CARTA.FileType, coordType: CARTA.CoordinateType, fileId: number, regionStyles: Map<number, CARTA.IRegionStyle>): Promise<CARTA.IExportRegionAck> {
+    async exportRegion(directory: string, file: string, type: CARTA.FileType, coordType: CARTA.CoordinateType, fileId: number, regionStyles: Map<number, CARTA.IRegionStyle>, overwrite: boolean = false): Promise<CARTA.IExportRegionAck> {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
-            const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(regionStyles), coordType});
+            const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(regionStyles), coordType, overwrite});
             const requestId = this.eventCounter;
             this.logEvent(CARTA.EventType.EXPORT_REGION, requestId, message, false);
             if (this.sendEvent(CARTA.EventType.EXPORT_REGION, CARTA.ExportRegion.encode(message).finish())) {
@@ -471,12 +471,13 @@ export class MessageController {
         channels?: number[],
         stokes?: number[],
         keepDegenerate?: boolean,
-        restFreq?: number
+        restFreq?: number,
+        overwrite: boolean = false
     ): Promise<CARTA.ISaveFileAck> {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
-            const message = CARTA.SaveFile.create({fileId, outputFileDirectory, outputFileName, outputFileType, regionId, channels, stokes, keepDegenerate, restFreq});
+            const message = CARTA.SaveFile.create({fileId, outputFileDirectory, outputFileName, outputFileType, regionId, channels, stokes, keepDegenerate, restFreq, overwrite});
             const requestId = this.eventCounter;
             this.logEvent(CARTA.EventType.SAVE_FILE, this.eventCounter, message, false);
             if (this.sendEvent(CARTA.EventType.SAVE_FILE, CARTA.SaveFile.encode(message).finish())) {
@@ -960,6 +961,19 @@ export class MessageController {
         } else {
             console.log(`Can't find deferred for request ${eventId}`);
         }
+    }
+
+    private onSaveFileAndRegionAck(eventId: number, ack: CARTA.SaveFileAck | CARTA.ExportRegionAck) {
+        // to check the overwriteConfirmationRequired field, return the entire response instead of the message field
+        if (!ack.success) {
+            const def = this.deferredMap.get(eventId);
+            if (def) {
+                def.reject(ack);
+            } else {
+                console.log(`Can't find deferred for request ${eventId}`);
+            }
+        }
+        this.onDeferredResponse(eventId, ack);
     }
 
     private onRegisterViewerAck(eventId: number, ack: CARTA.RegisterViewerAck) {

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -157,7 +157,8 @@ export class MessageController {
             [CARTA.EventType.FITTING_PROGRESS, {messageClass: CARTA.FittingProgress, handler: this.onStreamedFittingProgress}],
             [CARTA.EventType.FITTING_RESPONSE, {messageClass: CARTA.FittingResponse, handler: this.onDeferredResponse}],
             [CARTA.EventType.VECTOR_OVERLAY_TILE_DATA, {messageClass: CARTA.VectorOverlayTileData, handler: this.onStreamedVectorOverlayData}],
-            [CARTA.EventType.PV_PREVIEW_DATA, {messageClass: CARTA.PvPreviewData, handler: this.onStreamedPvPreviewData}]
+            [CARTA.EventType.PV_PREVIEW_DATA, {messageClass: CARTA.PvPreviewData, handler: this.onStreamedPvPreviewData}],
+            [CARTA.EventType.REMOTE_FILE_RESPONSE, {messageClass: CARTA.RemoteFileResponse, handler: this.onDeferredResponse}]
         ]);
 
         // check ping every 5 seconds
@@ -801,6 +802,22 @@ export class MessageController {
             this.logEvent(CARTA.EventType.PV_REQUEST, requestId, message, false);
             if (this.sendEvent(CARTA.EventType.PV_REQUEST, CARTA.PvRequest.encode(message).finish())) {
                 const deferredResponse = new Deferred<CARTA.IPvResponse>();
+                this.deferredMap.set(requestId, deferredResponse);
+                return await deferredResponse.promise;
+            } else {
+                throw new Error("Could not send event");
+            }
+        }
+    }
+
+    async requestRemoteFile(message: CARTA.IRemoteFileRequest): Promise<CARTA.IRemoteFileResponse> {
+        if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+            throw new Error("Not connected");
+        } else {
+            const requestId = this.eventCounter;
+            this.logEvent(CARTA.EventType.REMOTE_FILE_REQUEST, requestId, message, false);
+            if (this.sendEvent(CARTA.EventType.REMOTE_FILE_REQUEST, CARTA.RemoteFileRequest.encode(message).finish())) {
+                const deferredResponse = new Deferred<CARTA.IRemoteFileResponse>();
                 this.deferredMap.set(requestId, deferredResponse);
                 return await deferredResponse.promise;
             } else {

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -364,7 +364,7 @@ export class MessageController {
         }
     }
 
-    async exportRegion(directory: string, file: string, type: CARTA.FileType, coordType: CARTA.CoordinateType, fileId: number, regionStyles: Map<number, CARTA.IRegionStyle>, overwrite: boolean = false): Promise<CARTA.IExportRegionAck> {
+    async exportRegion(directory: string, file: string, type: CARTA.FileType, coordType: CARTA.CoordinateType, fileId: number, regionStyles: Map<number, CARTA.IRegionStyle>, overwrite: boolean = true): Promise<CARTA.IExportRegionAck> {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
@@ -472,7 +472,7 @@ export class MessageController {
         stokes?: number[],
         keepDegenerate?: boolean,
         restFreq?: number,
-        overwrite: boolean = false
+        overwrite: boolean = true
     ): Promise<CARTA.ISaveFileAck> {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");

--- a/src/test/SAVE_IMAGE_ERROR_MESSAGE.test.ts
+++ b/src/test/SAVE_IMAGE_ERROR_MESSAGE.test.ts
@@ -57,7 +57,7 @@ let assertItem: AssertItem = {
             keepDegenerate: true,
         },
     ],
-    errorMessage:"The selected region is entirely outside the image"
+    errorMessage: "The selected region is entirely outside the image."
 }
 
 let basepath: string;
@@ -94,7 +94,7 @@ describe("SAVE_IMAGE_ERROR_MESSAGE: Exporting of a region out of the image", () 
                 try { 
                     let saveFileResponse = await msgController.saveFile(SaveImageInput.fileId, tmpdirectory, SaveImageInput.outputFileName, SaveImageInput.outputFileType, SaveImageInput.regionId, SaveImageInput.channels, SaveImageInput.stokes, SaveImageInput.keepDegenerate, SaveImageInput.restFreq);
                 } catch (err) {
-                    expect(err).toContain(assertItem.errorMessage);
+                    expect(err.message).toContain(assertItem.errorMessage);
                 }
             }, saveFileTimeout);
         });


### PR DESCRIPTION
**Description**

This PR is fixed the backend dev PR merged (https://github.com/CARTAvis/carta-backend/pull/1378) and the protobuf merged PR (https://github.com/CARTAvis/carta-protobuf/pull/97) induced the tests failure.
I modify the `ICD-RxJS/src/test/MessageController.ts` and `ICD-RxJS/src/performance/MessageController.ts` based on the frontend merged PR (https://github.com/CARTAvis/carta-frontend/pull/2389)  `carta-frontend/src/services/BackendService.ts` .
About the new added overwrite, I set all of the overwrite as true, which is different to the frontend set as false.

This PR has been tested on the Ming-Yi's ASIAA two Desktop computers: MacOS 13 & Ubuntu 22.04, besides the known failure (src/test/MATCH_STATS_WIDE_BORDERLINE.test.ts) on Ubuntu 22.04, they are all passed.

**Checklist**

For the pull request:
- [x] The Document unchange / ~~Need update the Document~~
