### PR TITLE
add missing restFreq parameter to momentRequest message

### DIFF
--- a/src/performance/PERF_MOMENTS_CASA.test.ts
+++ b/src/performance/PERF_MOMENTS_CASA.test.ts
@@ -59,6 +59,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 0, max: 400 },
+        restFreq: 335500000000,
     },
 };
 const momentName = [

--- a/src/performance/PERF_MOMENTS_FITS.test.ts
+++ b/src/performance/PERF_MOMENTS_FITS.test.ts
@@ -59,6 +59,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 0, max: 400 },
+        restFreq: 335500000000,
     },
 };
 const momentName = [

--- a/src/performance/PERF_MOMENTS_HDF5.test.ts
+++ b/src/performance/PERF_MOMENTS_HDF5.test.ts
@@ -59,6 +59,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 0, max: 400 },
+        restFreq: 335500000000,
     },
 };
 const momentName = [

--- a/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
@@ -37,6 +37,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 73, max: 114 },
+        restFreq: 230538000000,
     },
 };
 

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -56,6 +56,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 73, max: 114 },
+        restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],

--- a/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
+++ b/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
@@ -40,6 +40,7 @@ let assertItem: AssertItem = {
             moments: [1, 0, 2],
             pixelRange: { min: 0.1, max: 1.0 },
             spectralRange: { min: 73, max: 114 },
+            restFreq: 230538000000,
         },
         {
             fileId: 0,

--- a/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
+++ b/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
@@ -51,6 +51,7 @@ let assertItem: AssertItem = {
             moments: [0, 1],
             pixelRange: { min: 0.1, max: 1.0 },
             spectralRange: { min: 73, max: 114 },
+            restFreq: 230538000000,
         },
     ],
     setCursor: {

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -56,6 +56,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 73, max: 114 },
+        restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -56,6 +56,7 @@ let assertItem: AssertItem = {
         moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 73, max: 114 },
+        restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -40,6 +40,7 @@ let assertItem: AssertItem = {
         moments: [0, 1,],
         pixelRange: { min: 0.1, max: 1.0 },
         spectralRange: { min: 73, max: 114 },
+        restFreq: 230538000000,
     },
     saveFile: [
         [

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -1,6 +1,6 @@
 {
     "serverURL0": "ws://127.0.0.1:3002",	
-    "icdVersion": 28,
+    "icdVersion": 29,
     "path": {
         "root": ".",
         "base": "$BASE",


### PR DESCRIPTION
**Description**
The backend PR https://github.com/CARTAvis/carta-backend/pull/1387 has an update to the protobuf message "momentRequest" with a new restFreq parameter. The fix here is to add it to the test scripts.  


**Checklist**

For the pull request:
- [x] ~The Document unchange~ / Need update the Document
https://docs.google.com/document/d/19hyLFcgC9XaMiGa9g8Lw_scQRXZLDFNDTetm7GPSCaI/edit?tab=t.0 updated
