### PR TITLE
Fix the high-severity NPM vulnerability warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "rxjs": "^7.8.1",
     "typescript": "^4.1.5"
   },
+  "overrides": {
+    "nth-check": "^2.1.1"
+  },
   "scripts": {
     "test": "react-scripts test --env=node --maxWorkers=1 --verbose --no-cache --forceExit"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "react-scripts": "^0.0.0",
+    "react-scripts": "^5.0.1",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "react-scripts": "^5.0.1",
+    "react-scripts": "^0.0.0",
     "ws": "^8.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description**

This PR addresses the high-severity NPM vulnerability warnings related to the `nth-check` package and ensures version consistency under `react-scripts@5.0.1`. 

The `npm audit report` flagged nth-check <2.0.1 as vulnerable.

```
nth-check  <2.0.1
Severity: high
Inefficient Regular Expression Complexity in nth-check - https://github.com/advisories/GHSA-rp65-9cf3-cjxr
fix available via npm audit fix --force
```

Running `npm ls nth-check` revealed inconsistent versions (1.0.2 and 2.1.1) of nth-check within the react-scripts dependency tree:

```
carta-backend-icd-rxjs@1.0.0 /Users/mark/tmp/ICD-RxJS
└─┬ react-scripts@5.0.1
  ├─┬ @svgr/webpack@5.5.0
  │ └─┬ @svgr/plugin-svgo@5.5.0
  │   └─┬ svgo@1.3.2
  │     └─┬ css-select@2.1.0
  │       └── nth-check@1.0.2
  └─┬ html-webpack-plugin@5.6.4
    └─┬ pretty-error@4.0.0
      └─┬ renderkid@3.0.0
        └─┬ css-select@4.3.0
          └── nth-check@2.1.1
```

To resolve this, the nth-check version is overridden in `package.json` to ensure a consistent and secure version:

```
"overrides": {
    "nth-check": "^2.1.1"
  }
```

**Checklist**

For the pull request:
- [x] The Document unchange ~/ Need update the Document~
