### PR TITLE
Posh/linux zfp update

### DIFF
--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -467,8 +467,8 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                 }
             }
             if (platformOS === 'Linux') {
-                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
-                isRhel8 = Response.includes('AlmaLinux 8') || Response.includes('Red Hat Enterprise Linux release 8');
+                let Response = String(execSync('cat /etc/redhat-release', {encoding:'utf-8'}));
+                isRhel8 = Response.includes('release 8');
             }
         }, connectTimeout);
 

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -366,7 +366,43 @@ let assertItem: AssertItem = {
             message: 'exceeded max number of iterations',
         },
     ],
-    fittingResponseLinux: [
+    fittingResponseRhel8: [
+        {
+            resultValues: [
+                {
+                    center: { x: 136.37672823927974, y: 279.5037991104328 },
+                    amp: 0.2904618522435351,
+                    fwhm: { x: 1.9853484080837196, y: 0.146547210359357 },
+                    pa: 269.45997949821316,
+                },
+                {
+                    center: { x: 324.3496961381463, y: 324.34883759659834 },
+                    amp: 9.997264701948565,
+                    fwhm: { x: 29.393895344533018, y: 117.4720630755205 },
+                    pa: 0.536583218147941,
+                },
+            ],
+            resultErrors: [
+                {
+                    center: {},
+                    fwhm: {},
+                },
+                {
+                    center: {
+                        x: 2.646707864394448e-9,
+                        y: 6.628377900916031e-10,
+                    },
+                    amp: 5.30228693940221e-10,
+                    fwhm: { x: 1.5598400660409465e-9, y: 6.232777004216184e-9 },
+                    pa: 1.147613998115689e-9,
+                },
+            ],
+            success: true,
+            log: 'Gaussian fitting with 2 component',
+            message: 'exceeded max number of iterations',
+        },
+    ],
+    fittingResponseUbuntu: [
         {
             resultValues: [
                 {
@@ -410,6 +446,7 @@ let MacOSNumber: any;
 let MacOSNumberResponse: any;
 let chipVersion: any;
 let ubuntuNumber: any;
+let isRhel8: boolean = false;
 let MacChipM1: boolean = false;
 let basepath: string;
 describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) with fits file.', () => {
@@ -428,6 +465,10 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                 if (MacOSNumberResponse.toString().includes('11.6.1')) {
                     MacOSNumber = '11.6.1';
                 }
+            }
+            if (platformOS === 'Linux') {
+                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
+                isRhel8 = Response.includes('AlmaLinux 8') || Response.includes('Red Hat Enterprise Linux release 8');
             }
         }, connectTimeout);
 
@@ -998,88 +1039,170 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
 
                         expect(response.log).toContain(assertItem.fittingResponseMacOS15M1[0].log);
                         expect(response.message).toContain(assertItem.fittingResponseMacOS15M1[0].message);
-                    } else if (platformOS === 'Linux') {
+                    } else if (platformOS === 'Linux' && isRhel8 === true) {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[0].center.x,
+                            assertItem.fittingResponseRhel8[0].resultValues[0].center.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].center.y).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[0].center.y,
+                            assertItem.fittingResponseRhel8[0].resultValues[0].center.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].amp).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[0].amp,
+                            assertItem.fittingResponseRhel8[0].resultValues[0].amp,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[0].fwhm.x,
+                            assertItem.fittingResponseRhel8[0].resultValues[0].fwhm.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[0].fwhm.y,
+                            assertItem.fittingResponseRhel8[0].resultValues[0].fwhm.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].pa).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[0].pa,
+                            assertItem.fittingResponseRhel8[0].resultValues[0].pa,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[1].center.x,
+                            assertItem.fittingResponseRhel8[0].resultValues[1].center.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[1].center.y,
+                            assertItem.fittingResponseRhel8[0].resultValues[1].center.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[1].amp,
+                            assertItem.fittingResponseRhel8[0].resultValues[1].amp,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[1].fwhm.x,
+                            assertItem.fittingResponseRhel8[0].resultValues[1].fwhm.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[1].fwhm.y,
+                            assertItem.fittingResponseRhel8[0].resultValues[1].fwhm.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultValues[1].pa,
+                            assertItem.fittingResponseRhel8[0].resultValues[1].pa,
                             assertItem.precisionDigits
                         );
-                        expect(response.success).toEqual(assertItem.fittingResponseLinux[0].success);
+                        expect(response.success).toEqual(assertItem.fittingResponseRhel8[0].success);
 
                         expect(response.resultErrors[0].center.x).toBeCloseTo(0);
                         expect(response.resultErrors[0].center.y).toBeCloseTo(0);
                         expect(response.resultErrors[0].fwhm.x).toBeCloseTo(0);
                         expect(response.resultErrors[0].fwhm.y).toBeCloseTo(0);
                         expect(response.resultErrors[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultErrors[1].center.x,
+                            assertItem.fittingResponseRhel8[0].resultErrors[1].center.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultErrors[1].center.y,
+                            assertItem.fittingResponseRhel8[0].resultErrors[1].center.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultErrors[1].amp,
+                            assertItem.fittingResponseRhel8[0].resultErrors[1].amp,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultErrors[1].fwhm.x,
+                            assertItem.fittingResponseRhel8[0].resultErrors[1].fwhm.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultErrors[1].fwhm.y,
+                            assertItem.fittingResponseRhel8[0].resultErrors[1].fwhm.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseLinux[0].resultErrors[1].pa,
+                            assertItem.fittingResponseRhel8[0].resultErrors[1].pa,
                             assertItem.precisionDigits
                         );
 
-                        expect(response.log).toContain(assertItem.fittingResponseLinux[0].log);
-                        expect(response.message).toContain(assertItem.fittingResponseLinux[0].message);
+                        expect(response.log).toContain(assertItem.fittingResponseRhel8[0].log);
+                        expect(response.message).toContain(assertItem.fittingResponseRhel8[0].message);
+                    } else if (platformOS === 'Linux' && isRhel8 === false) {
+                        expect(response.resultValues[0].center.x).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].center.x,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[0].center.y).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].center.y,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[0].amp).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].amp,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[0].fwhm.x).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].fwhm.x,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[0].fwhm.y).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].fwhm.y,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[0].pa).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[1].center.x).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].center.x,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[1].center.y).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].center.y,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[1].amp).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].amp,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[1].fwhm.x).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].fwhm.x,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[1].fwhm.y).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].fwhm.y,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultValues[1].pa).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.success).toEqual(assertItem.fittingResponseUbuntu[0].success);
+
+                        expect(response.resultErrors[0].center.x).toBeCloseTo(0);
+                        expect(response.resultErrors[0].center.y).toBeCloseTo(0);
+                        expect(response.resultErrors[0].fwhm.x).toBeCloseTo(0);
+                        expect(response.resultErrors[0].fwhm.y).toBeCloseTo(0);
+                        expect(response.resultErrors[1].center.x).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].center.x,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultErrors[1].center.y).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].center.y,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultErrors[1].amp).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].amp,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultErrors[1].fwhm.x).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].fwhm.x,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultErrors[1].fwhm.y).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].fwhm.y,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.resultErrors[1].pa).toBeCloseTo(
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].pa,
+                            assertItem.precisionDigits
+                        );
+
+                        expect(response.log).toContain(assertItem.fittingResponseUbuntu[0].log);
+                        expect(response.message).toContain(assertItem.fittingResponseUbuntu[0].message);
                     } else {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
                             assertItem.fittingResponse[0].resultValues[0].center.x,

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -467,7 +467,7 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                 }
             }
             if (platformOS === 'Linux') {
-                let Response = String(execSync('cat /etc/redhat-release', {encoding:'utf-8'}));
+                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
                 isRhel8 = Response.includes('release 8');
             }
         }, connectTimeout);

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -26,8 +26,7 @@ interface AssertItem {
     fittingResponseMacOS14Intel: CARTA.IFittingResponse[];
     fittingResponseMacOS15M1: CARTA.IFittingResponse[];
     fittingResponseLinux: CARTA.IFittingResponse[];
-    fittingResponseUbuntu2204: CARTA.IFittingResponse[];
-    fittingResponseUbuntu2404: CARTA.IFittingResponse[];
+    fittingResponseUbuntu: CARTA.IFittingResponse[];
     precisionDigits: number;
 }
 
@@ -404,43 +403,7 @@ let assertItem: AssertItem = {
             message: 'exceeded max number of iterations',
         },
     ],
-    fittingResponseUbuntu2204: [
-        {
-            resultValues: [
-                {
-                    center: { x: 135.6039671553926, y: 279.3982090340097 },
-                    amp: 0.2667783422848237,
-                    fwhm: { x: 0.00663387750450295, y: 0.25375495985499164 },
-                    pa: 268.82156926726475,
-                },
-                {
-                    center: { x: 324.3548469822517, y: 324.3493131416585 },
-                    amp: 9.996067823419335,
-                    fwhm: { x: 29.404786487293283, y: 117.49510621189104 },
-                    pa: 0.5401367844577657,
-                },
-            ],
-            resultErrors: [
-                {
-                    center: {},
-                    fwhm: {},
-                },
-                {
-                    center: {
-                        x: 2.646221869634662e-9,
-                        y: 6.627293636592795e-10,
-                    },
-                    amp: 5.30201596436001e-10,
-                    fwhm: { x: 1.55959026052576e-9, y: 6.231631197843904e-9 },
-                    pa: 1.1473887943482772e-9,
-                },
-            ],
-            success: true,
-            log: 'Gaussian fitting with 2 component',
-            message: 'exceeded max number of iterations',
-        },
-    ],
-    fittingResponseUbuntu2404: [
+    fittingResponseUbuntu: [
         {
             resultValues: [
                 {
@@ -484,8 +447,7 @@ let MacOSNumber: any;
 let MacOSNumberResponse: any;
 let chipVersion: any;
 let ubuntuNumber: any;
-let isUbunutu2204orRedHat9: boolean;
-let isUbunutu2404: boolean;
+let isUbuntu: boolean;
 let MacChipM1: boolean = false;
 let basepath: string;
 describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) with fits file.', () => {
@@ -507,9 +469,7 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
             }
             if (platformOS === 'Linux') {
                 let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
-                isUbunutu2204orRedHat9 =
-                    Response.includes('22.04') || Response.includes('24.04') || Response.includes('AlmaLinux 9.3');
-                isUbunutu2404 = Response.includes('24.04');
+                isUbuntu = Response.includes('Ubuntu');
             }
         }, connectTimeout);
 
@@ -1080,7 +1040,7 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
 
                         expect(response.log).toContain(assertItem.fittingResponseMacOS15M1[0].log);
                         expect(response.message).toContain(assertItem.fittingResponseMacOS15M1[0].message);
-                    } else if (platformOS === 'Linux' && isUbunutu2204orRedHat9 === false) {
+                    } else if (platformOS === 'Linux' && isUbuntu === false) {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
                             assertItem.fittingResponseLinux[0].resultValues[0].center.x,
                             assertItem.precisionDigits
@@ -1162,170 +1122,88 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
 
                         expect(response.log).toContain(assertItem.fittingResponseLinux[0].log);
                         expect(response.message).toContain(assertItem.fittingResponseLinux[0].message);
-                    } else if (platformOS === 'Linux' && isUbunutu2204orRedHat9 === true && isUbunutu2404 === false) {
+                    } else if (platformOS === 'Linux' && isUbuntu === true) {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[0].center.x,
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].center.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[0].center.y,
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].center.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[0].amp,
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].amp,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[0].fwhm.x,
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].fwhm.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[0].fwhm.y,
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].fwhm.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[0].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[0].pa,
+                            assertItem.fittingResponseUbuntu[0].resultValues[0].pa,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[1].center.x,
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].center.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[1].center.y,
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].center.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[1].amp,
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].amp,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[1].fwhm.x,
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].fwhm.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[1].fwhm.y,
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].fwhm.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultValues[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultValues[1].pa,
+                            assertItem.fittingResponseUbuntu[0].resultValues[1].pa,
                             assertItem.precisionDigits
                         );
-                        expect(response.success).toEqual(assertItem.fittingResponseUbuntu2204[0].success);
+                        expect(response.success).toEqual(assertItem.fittingResponseUbuntu[0].success);
 
                         expect(response.resultErrors[0].center.x).toBeCloseTo(0);
                         expect(response.resultErrors[0].center.y).toBeCloseTo(0);
                         expect(response.resultErrors[0].fwhm.x).toBeCloseTo(0);
                         expect(response.resultErrors[0].fwhm.y).toBeCloseTo(0);
                         expect(response.resultErrors[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultErrors[1].center.x,
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].center.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultErrors[1].center.y,
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].center.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultErrors[1].amp,
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].amp,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultErrors[1].fwhm.x,
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].fwhm.x,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultErrors[1].fwhm.y,
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].fwhm.y,
                             assertItem.precisionDigits
                         );
                         expect(response.resultErrors[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2204[0].resultErrors[1].pa,
+                            assertItem.fittingResponseUbuntu[0].resultErrors[1].pa,
                             assertItem.precisionDigits
                         );
 
-                        expect(response.log).toContain(assertItem.fittingResponseUbuntu2204[0].log);
-                        expect(response.message).toContain(assertItem.fittingResponseUbuntu2204[0].message);
-                    } else if (platformOS === 'Linux' && isUbunutu2204orRedHat9 === true && isUbunutu2404 === true) {
-                        expect(response.resultValues[0].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[0].center.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[0].center.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[0].amp,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[0].fwhm.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[0].fwhm.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[0].pa,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[1].center.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[1].center.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[1].amp,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[1].fwhm.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[1].fwhm.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultValues[1].pa,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.success).toEqual(assertItem.fittingResponseUbuntu2404[0].success);
-
-                        expect(response.resultErrors[0].center.x).toBeCloseTo(0);
-                        expect(response.resultErrors[0].center.y).toBeCloseTo(0);
-                        expect(response.resultErrors[0].fwhm.x).toBeCloseTo(0);
-                        expect(response.resultErrors[0].fwhm.y).toBeCloseTo(0);
-                        expect(response.resultErrors[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultErrors[1].center.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultErrors[1].center.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultErrors[1].amp,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultErrors[1].fwhm.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultErrors[1].fwhm.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu2404[0].resultErrors[1].pa,
-                            assertItem.precisionDigits
-                        );
-
-                        expect(response.log).toContain(assertItem.fittingResponseUbuntu2404[0].log);
-                        expect(response.message).toContain(assertItem.fittingResponseUbuntu2404[0].message);
+                        expect(response.log).toContain(assertItem.fittingResponseUbuntu[0].log);
+                        expect(response.message).toContain(assertItem.fittingResponseUbuntu[0].message);
                     } else {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
                             assertItem.fittingResponse[0].resultValues[0].center.x,

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -26,7 +26,6 @@ interface AssertItem {
     fittingResponseMacOS14Intel: CARTA.IFittingResponse[];
     fittingResponseMacOS15M1: CARTA.IFittingResponse[];
     fittingResponseLinux: CARTA.IFittingResponse[];
-    fittingResponseUbuntu: CARTA.IFittingResponse[];
     precisionDigits: number;
 }
 
@@ -371,42 +370,6 @@ let assertItem: AssertItem = {
         {
             resultValues: [
                 {
-                    center: { x: 136.37672823927974, y: 279.5037991104328 },
-                    amp: 0.2904618522435351,
-                    fwhm: { x: 1.9853484080837196, y: 0.146547210359357 },
-                    pa: 269.45997949821316,
-                },
-                {
-                    center: { x: 324.3496961381463, y: 324.34883759659834 },
-                    amp: 9.997264701948565,
-                    fwhm: { x: 29.393895344533018, y: 117.4720630755205 },
-                    pa: 0.536583218147941,
-                },
-            ],
-            resultErrors: [
-                {
-                    center: {},
-                    fwhm: {},
-                },
-                {
-                    center: {
-                        x: 2.646707864394448e-9,
-                        y: 6.628377900916031e-10,
-                    },
-                    amp: 5.30228693940221e-10,
-                    fwhm: { x: 1.5598400660409465e-9, y: 6.232777004216184e-9 },
-                    pa: 1.147613998115689e-9,
-                },
-            ],
-            success: true,
-            log: 'Gaussian fitting with 2 component',
-            message: 'exceeded max number of iterations',
-        },
-    ],
-    fittingResponseUbuntu: [
-        {
-            resultValues: [
-                {
                     center: { x: 135.6039671553926, y: 279.3982090340097 },
                     amp: 0.2667783422848237,
                     fwhm: { x: 0.00663387750450295, y: 0.25375495985499164 },
@@ -447,7 +410,6 @@ let MacOSNumber: any;
 let MacOSNumberResponse: any;
 let chipVersion: any;
 let ubuntuNumber: any;
-let isUbuntu: boolean;
 let MacChipM1: boolean = false;
 let basepath: string;
 describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) with fits file.', () => {
@@ -466,10 +428,6 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                 if (MacOSNumberResponse.toString().includes('11.6.1')) {
                     MacOSNumber = '11.6.1';
                 }
-            }
-            if (platformOS === 'Linux') {
-                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
-                isUbuntu = Response.includes('Ubuntu');
             }
         }, connectTimeout);
 
@@ -1040,7 +998,7 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
 
                         expect(response.log).toContain(assertItem.fittingResponseMacOS15M1[0].log);
                         expect(response.message).toContain(assertItem.fittingResponseMacOS15M1[0].message);
-                    } else if (platformOS === 'Linux' && isUbuntu === false) {
+                    } else if (platformOS === 'Linux') {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
                             assertItem.fittingResponseLinux[0].resultValues[0].center.x,
                             assertItem.precisionDigits
@@ -1122,88 +1080,6 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
 
                         expect(response.log).toContain(assertItem.fittingResponseLinux[0].log);
                         expect(response.message).toContain(assertItem.fittingResponseLinux[0].message);
-                    } else if (platformOS === 'Linux' && isUbuntu === true) {
-                        expect(response.resultValues[0].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[0].center.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[0].center.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[0].amp,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[0].fwhm.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[0].fwhm.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[0].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[0].pa,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[1].center.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[1].center.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[1].amp,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[1].fwhm.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[1].fwhm.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultValues[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultValues[1].pa,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.success).toEqual(assertItem.fittingResponseUbuntu[0].success);
-
-                        expect(response.resultErrors[0].center.x).toBeCloseTo(0);
-                        expect(response.resultErrors[0].center.y).toBeCloseTo(0);
-                        expect(response.resultErrors[0].fwhm.x).toBeCloseTo(0);
-                        expect(response.resultErrors[0].fwhm.y).toBeCloseTo(0);
-                        expect(response.resultErrors[1].center.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultErrors[1].center.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].center.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultErrors[1].center.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].amp).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultErrors[1].amp,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].fwhm.x).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultErrors[1].fwhm.x,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].fwhm.y).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultErrors[1].fwhm.y,
-                            assertItem.precisionDigits
-                        );
-                        expect(response.resultErrors[1].pa).toBeCloseTo(
-                            assertItem.fittingResponseUbuntu[0].resultErrors[1].pa,
-                            assertItem.precisionDigits
-                        );
-
-                        expect(response.log).toContain(assertItem.fittingResponseUbuntu[0].log);
-                        expect(response.message).toContain(assertItem.fittingResponseUbuntu[0].message);
                     } else {
                         expect(response.resultValues[0].center.x).toBeCloseTo(
                             assertItem.fittingResponse[0].resultValues[0].center.x,

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -19,7 +19,7 @@ interface AssertItem {
     setSpectralRequirements: CARTA.ISetSpectralRequirements;
     momentRequest: CARTA.IMomentRequest;
     imageDataLength: number[];
-    imageDataLength_linux: number[];
+    imageDataLength_ubuntu: number[];
     nanEncodingsLength: number[];
 }
 
@@ -64,7 +64,7 @@ let assertItem: AssertItem = {
         restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
-    imageDataLength_linux: [
+    imageDataLength_ubuntu: [
         72553, 72476, 59320, 67554, 74127, 32719, 68420, 72076, 70573, 67495, 32746, 76902, 61846,
     ],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
@@ -106,6 +106,7 @@ const imageData30000 = [
 
 let basepath: string;
 let platformOS: String;
+let isUbuntu: boolean;
 describe('MOMENTS_GENERATOR_CASA: Testing moments generator for a given region on a casa image', () => {
     function sleep(ms) {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -115,6 +116,10 @@ describe('MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
         beforeAll(async () => {
             let registerViewerAck = await msgController.connect(testServerUrl);
             platformOS = registerViewerAck.platformStrings.platform;
+            if (platformOS === 'Linux') {
+                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
+                isUbuntu = Response.includes('Ubuntu');
+            }
         }, connectTimeout);
 
         checkConnection();
@@ -275,8 +280,8 @@ describe('MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
                 RasterTileData.map((ack, index) => {
                     expect(ack.tiles[0].height).toEqual(201);
                     expect(ack.tiles[0].width).toEqual(201);
-                    if (platformOS === 'Linux') {
-                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_linux[index]);
+                    if (platformOS === 'Linux' && isUbuntu === true) {
+                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_ubuntu[index]);
                     } else {
                         expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
                     }

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -19,7 +19,7 @@ interface AssertItem {
     setSpectralRequirements: CARTA.ISetSpectralRequirements;
     momentRequest: CARTA.IMomentRequest;
     imageDataLength: number[];
-    imageDataLength_ubuntu2404: number[];
+    imageDataLength_linux: number[];
     nanEncodingsLength: number[];
 }
 
@@ -64,7 +64,7 @@ let assertItem: AssertItem = {
         restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
-    imageDataLength_ubuntu2404: [
+    imageDataLength_linux: [
         72553, 72476, 59320, 67554, 74127, 32719, 68420, 72076, 70573, 67495, 32746, 76902, 61846,
     ],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
@@ -106,7 +106,6 @@ const imageData30000 = [
 
 let basepath: string;
 let platformOS: String;
-let isUbunutu2404: boolean;
 describe('MOMENTS_GENERATOR_CASA: Testing moments generator for a given region on a casa image', () => {
     function sleep(ms) {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -116,10 +115,6 @@ describe('MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
         beforeAll(async () => {
             let registerViewerAck = await msgController.connect(testServerUrl);
             platformOS = registerViewerAck.platformStrings.platform;
-            if (platformOS === 'Linux') {
-                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
-                isUbunutu2404 = Response.includes('24.04');
-            }
         }, connectTimeout);
 
         checkConnection();
@@ -280,8 +275,8 @@ describe('MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
                 RasterTileData.map((ack, index) => {
                     expect(ack.tiles[0].height).toEqual(201);
                     expect(ack.tiles[0].width).toEqual(201);
-                    if (platformOS === 'Linux' && isUbunutu2404 === true) {
-                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_ubuntu2404[index]);
+                    if (platformOS === 'Linux') {
+                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_linux[index]);
                     } else {
                         expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
                     }

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -19,7 +19,7 @@ interface AssertItem {
     setSpectralRequirements: CARTA.ISetSpectralRequirements;
     momentRequest: CARTA.IMomentRequest;
     imageDataLength: number[];
-    imageDataLength_linux: number[];
+    imageDataLength_ubuntu: number[];
     nanEncodingsLength: number[];
 }
 
@@ -64,7 +64,7 @@ let assertItem: AssertItem = {
         restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
-    imageDataLength_linux: [
+    imageDataLength_ubuntu: [
         72553, 72476, 59320, 67554, 74127, 32719, 68420, 72076, 70573, 67495, 32746, 76902, 61846,
     ],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
@@ -106,6 +106,7 @@ const imageData30000 = [
 
 let basepath: string;
 let platformOS: String;
+let isUbuntu: boolean;
 describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region on a fits image', () => {
     function sleep(ms) {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -115,6 +116,10 @@ describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
         beforeAll(async () => {
             let registerViewerAck = await msgController.connect(testServerUrl);
             platformOS = registerViewerAck.platformStrings.platform;
+            if (platformOS === 'Linux') {
+                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
+                isUbuntu = Response.includes('Ubuntu');
+            }
         }, connectTimeout);
 
         checkConnection();
@@ -275,8 +280,8 @@ describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
                 RasterTileData.map((ack, index) => {
                     expect(ack.tiles[0].height).toEqual(201);
                     expect(ack.tiles[0].width).toEqual(201);
-                    if (platformOS === 'Linux') {
-                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_linux[index]);
+                    if (platformOS === 'Linux' && isUbuntu === true) {
+                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_ubuntu[index]);
                     } else {
                         expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
                     }

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -19,7 +19,7 @@ interface AssertItem {
     setSpectralRequirements: CARTA.ISetSpectralRequirements;
     momentRequest: CARTA.IMomentRequest;
     imageDataLength: number[];
-    imageDataLength_ubuntu2404: number[];
+    imageDataLength_linux: number[];
     nanEncodingsLength: number[];
 }
 
@@ -64,7 +64,7 @@ let assertItem: AssertItem = {
         restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
-    imageDataLength_ubuntu2404: [
+    imageDataLength_linux: [
         72553, 72476, 59320, 67554, 74127, 32719, 68420, 72076, 70573, 67495, 32746, 76902, 61846,
     ],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
@@ -106,7 +106,6 @@ const imageData30000 = [
 
 let basepath: string;
 let platformOS: String;
-let isUbunutu2404: boolean;
 describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region on a fits image', () => {
     function sleep(ms) {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -116,10 +115,6 @@ describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
         beforeAll(async () => {
             let registerViewerAck = await msgController.connect(testServerUrl);
             platformOS = registerViewerAck.platformStrings.platform;
-            if (platformOS === 'Linux') {
-                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
-                isUbunutu2404 = Response.includes('24.04');
-            }
         }, connectTimeout);
 
         checkConnection();
@@ -280,8 +275,8 @@ describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
                 RasterTileData.map((ack, index) => {
                     expect(ack.tiles[0].height).toEqual(201);
                     expect(ack.tiles[0].width).toEqual(201);
-                    if (platformOS === 'Linux' && isUbunutu2404 === true) {
-                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_ubuntu2404[index]);
+                    if (platformOS === 'Linux') {
+                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_linux[index]);
                     } else {
                         expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
                     }

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -19,7 +19,7 @@ interface AssertItem {
     setSpectralRequirements: CARTA.ISetSpectralRequirements;
     momentRequest: CARTA.IMomentRequest;
     imageDataLength: number[];
-    imageDataLength_linux: number[];
+    imageDataLength_ubuntu: number[];
     nanEncodingsLength: number[];
 }
 
@@ -64,7 +64,7 @@ let assertItem: AssertItem = {
         restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
-    imageDataLength_linux: [
+    imageDataLength_ubuntu: [
         72553, 72476, 59320, 67554, 74127, 32719, 68420, 72076, 70573, 67495, 32746, 76902, 61846,
     ],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
@@ -106,6 +106,7 @@ const imageData30000 = [
 
 let basepath: string;
 let platformOS: String;
+let isUbuntu: boolean;
 describe('MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region on a hdf5 image', () => {
     function sleep(ms) {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -115,6 +116,10 @@ describe('MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
         beforeAll(async () => {
             let registerViewerAck = await msgController.connect(testServerUrl);
             platformOS = registerViewerAck.platformStrings.platform;
+            if (platformOS === 'Linux') {
+                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
+                isUbuntu = Response.includes('Ubuntu');
+            }
         }, connectTimeout);
 
         checkConnection();
@@ -275,8 +280,8 @@ describe('MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
                 RasterTileData.map((ack, index) => {
                     expect(ack.tiles[0].height).toEqual(201);
                     expect(ack.tiles[0].width).toEqual(201);
-                    if (platformOS === 'Linux') {
-                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_linux[index]);
+                    if (platformOS === 'Linux' && isUbuntu === true) {
+                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_ubuntu[index]);
                     } else {
                         expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
                     }

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -19,7 +19,7 @@ interface AssertItem {
     setSpectralRequirements: CARTA.ISetSpectralRequirements;
     momentRequest: CARTA.IMomentRequest;
     imageDataLength: number[];
-    imageDataLength_ubuntu2404: number[];
+    imageDataLength_linux: number[];
     nanEncodingsLength: number[];
 }
 
@@ -64,7 +64,7 @@ let assertItem: AssertItem = {
         restFreq: 230538000000,
     },
     imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
-    imageDataLength_ubuntu2404: [
+    imageDataLength_linux: [
         72553, 72476, 59320, 67554, 74127, 32719, 68420, 72076, 70573, 67495, 32746, 76902, 61846,
     ],
     nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
@@ -106,7 +106,6 @@ const imageData30000 = [
 
 let basepath: string;
 let platformOS: String;
-let isUbunutu2404: boolean;
 describe('MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region on a hdf5 image', () => {
     function sleep(ms) {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -116,10 +115,6 @@ describe('MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
         beforeAll(async () => {
             let registerViewerAck = await msgController.connect(testServerUrl);
             platformOS = registerViewerAck.platformStrings.platform;
-            if (platformOS === 'Linux') {
-                let Response = String(execSync('lsb_release -a', { encoding: 'utf-8' }));
-                isUbunutu2404 = Response.includes('24.04');
-            }
         }, connectTimeout);
 
         checkConnection();
@@ -280,8 +275,8 @@ describe('MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
                 RasterTileData.map((ack, index) => {
                     expect(ack.tiles[0].height).toEqual(201);
                     expect(ack.tiles[0].width).toEqual(201);
-                    if (platformOS === 'Linux' && isUbunutu2404 === true) {
-                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_ubuntu2404[index]);
+                    if (platformOS === 'Linux') {
+                        expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength_linux[index]);
                     } else {
                         expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
                     }


### PR DESCRIPTION
**Description**

Changes to the ICD test format caused incompatibilities with older Ubuntu Node environments, therefore we rebuilt the apptainer images to upgrade Node and also upgraded ZFP to v1.0.1 at the same time.
To accommodate the upgraded ZFP version, we updated the expected values in the Moments and Fitting tests.

For the pull request:

## The image data length changed in upgraded OS, fixed:
‎src/test/MOMENTS_GENERATOR_CASA.test.ts
‎src/test/MOMENTS_GENERATOR_FITS.test.ts
‎src/test/MOMENTS_GENERATOR_HDF5.test.ts

## The fitting responses in rhel 8 and 9 are separated, which show different result values and errors, fixed:
src/test/IMAGE_FITTING_BAD.test.ts
