### PR TITLE
Posh/vector

### DIFF
--- a/src/test/VECTOR_OVERLAY_CASA.test.ts
+++ b/src/test/VECTOR_OVERLAY_CASA.test.ts
@@ -162,7 +162,7 @@ let assertItem: AssertItem = {
                 {
                     height: 25,
                     mip: 1,
-                    layer: 3,
+                    layer: -1,
                     width: 25,
                     x: 4,
                     y: 4,
@@ -172,7 +172,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 25,
-                    layer: 3,
+                    layer: -1,
                     mip: 1,
                     width: 25,
                     x: 4,
@@ -193,7 +193,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -204,7 +204,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -225,7 +225,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -236,7 +236,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -257,7 +257,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -268,7 +268,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -289,7 +289,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 13,
-                    layer: 2,
+                    layer: -1,
                     mip: 2,
                     width: 13,
                     x: 2,
@@ -300,7 +300,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 13,
-                    layer: 2,
+                    layer: -1,
                     mip: 2,
                     width: 13,
                     x: 2,
@@ -321,7 +321,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -340,7 +340,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,

--- a/src/test/VECTOR_OVERLAY_CHANNEL_STREAM.test.ts
+++ b/src/test/VECTOR_OVERLAY_CHANNEL_STREAM.test.ts
@@ -81,7 +81,7 @@ let assertItem: AssertItem = {
                 {
                     height: 7,
                     mip: 4,
-                    layer: 1,
+                    layer: -1,
                     width: 7,
                     x: 1,
                     y: 1,
@@ -91,7 +91,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -114,7 +114,7 @@ let assertItem: AssertItem = {
                 {
                     height: 7,
                     mip: 4,
-                    layer: 1,
+                    layer: -1,
                     width: 7,
                     x: 1,
                     y: 1,
@@ -124,7 +124,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,

--- a/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
+++ b/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
@@ -120,7 +120,7 @@ let assertItem: AssertItem = {
                 {
                     height: 25,
                     mip: 1,
-                    layer: 3,
+                    layer: -1,
                     width: 25,
                     x: 4,
                     y: 4,
@@ -130,7 +130,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 25,
-                    layer: 3,
+                    layer: -1,
                     mip: 1,
                     width: 25,
                     x: 4,
@@ -154,7 +154,7 @@ let assertItem: AssertItem = {
                 {
                     height: 7,
                     mip: 4,
-                    layer: 1,
+                    layer: -1,
                     width: 7,
                     x: 1,
                     y: 1,
@@ -164,7 +164,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -188,7 +188,7 @@ let assertItem: AssertItem = {
                 {
                     height: 7,
                     mip: 4,
-                    layer: 1,
+                    layer: -1,
                     width: 7,
                     x: 1,
                     y: 1,
@@ -198,7 +198,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,

--- a/src/test/VECTOR_OVERLAY_FITS.test.ts
+++ b/src/test/VECTOR_OVERLAY_FITS.test.ts
@@ -162,7 +162,7 @@ let assertItem: AssertItem = {
                 {
                     height: 25,
                     mip: 1,
-                    layer: 3,
+                    layer: -1,
                     width: 25,
                     x: 4,
                     y: 4,
@@ -172,7 +172,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 25,
-                    layer: 3,
+                    layer: -1,
                     mip: 1,
                     width: 25,
                     x: 4,
@@ -193,7 +193,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -204,7 +204,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -225,7 +225,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -236,7 +236,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -257,7 +257,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -268,7 +268,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -289,7 +289,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 13,
-                    layer: 2,
+                    layer: -1,
                     mip: 2,
                     width: 13,
                     x: 2,
@@ -300,7 +300,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 13,
-                    layer: 2,
+                    layer: -1,
                     mip: 2,
                     width: 13,
                     x: 2,
@@ -321,7 +321,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -340,7 +340,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,

--- a/src/test/VECTOR_OVERLAY_HDF5.test.ts
+++ b/src/test/VECTOR_OVERLAY_HDF5.test.ts
@@ -162,7 +162,7 @@ let assertItem: AssertItem = {
                 {
                     height: 25,
                     mip: 1,
-                    layer: 3,
+                    layer: -1,
                     width: 25,
                     x: 4,
                     y: 4,
@@ -172,7 +172,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 25,
-                    layer: 3,
+                    layer: -1,
                     mip: 1,
                     width: 25,
                     x: 4,
@@ -193,7 +193,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -204,7 +204,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -225,7 +225,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -236,7 +236,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -257,7 +257,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -268,7 +268,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -289,7 +289,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 13,
-                    layer: 2,
+                    layer: -1,
                     mip: 2,
                     width: 13,
                     x: 2,
@@ -300,7 +300,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 13,
-                    layer: 2,
+                    layer: -1,
                     mip: 2,
                     width: 13,
                     x: 2,
@@ -321,7 +321,7 @@ let assertItem: AssertItem = {
             angleTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,
@@ -340,7 +340,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 7,
-                    layer: 1,
+                    layer: -1,
                     mip: 4,
                     width: 7,
                     x: 1,

--- a/src/test/VECTOR_OVERLAY_NO_POLARIZATION.test.ts
+++ b/src/test/VECTOR_OVERLAY_NO_POLARIZATION.test.ts
@@ -76,7 +76,7 @@ let assertItem: AssertItem = {
                 {
                     height: 144,
                     mip: 2,
-                    layer: 1,
+                    layer: -1,
                     width: 64,
                     x: 1,
                     y: 1,
@@ -86,7 +86,7 @@ let assertItem: AssertItem = {
             intensityTiles: [
                 {
                     height: 144,
-                    layer: 1,
+                    layer: -1,
                     mip: 2,
                     width: 64,
                     x: 1,


### PR DESCRIPTION
**Description**

Backend issue #1488  removed MipToLayer function and set layer to -1 ("src/DataStream/VectorField.cc" ).
Therefore, the layer in VectorOverlayTileData (VECTOR_OVERLAY_*.test.ts) should be set to -1, too.

**Checklist**
ICD test passing
