### PR TITLE
Improve GitHub Actions: parallel tests, log artifacts, port fixes

### DIFF
--- a/.github/actions/run-apptainer/action.yml
+++ b/.github/actions/run-apptainer/action.yml
@@ -2,7 +2,7 @@ name: 'Run ICD tests via Apptainer'
 description: 'Start carta_backend and run ICD tests'
 inputs:
   os_version:
-    description: 'Platfrom'
+    description: 'Platform'
     required: true
   image:
     description: 'Apptainer image'
@@ -17,7 +17,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: |
+    - name: Run ICD tests via Apptainer
+      run: |
         set -eo pipefail  # Make script exit on any error
     
         SRC_DIR=$GITHUB_WORKSPACE/source
@@ -76,3 +77,11 @@ runs:
               exit 1
             fi"
       shell: bash
+
+    - name: Upload backend log on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: carta-backend-log-${{ inputs.os_version }}-${{ inputs.test_stage_name }}
+        path: /tmp/carta_icd_${{ inputs.os_version }}_${{ inputs.test_stage_name }}.log
+        retention-days: 14

--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -4,37 +4,67 @@ inputs:
   test_stage_name:
     description: 'ICD test stage'
     required: true
+  port:
+    description: 'Port number for carta_backend'
+    required: false
+    default: '5555'
 runs:
   using: 'composite'
   steps:
     - name: Check backend dynamic linking
-      run: otool -L ./carta_backend
+      run: otool -L $GITHUB_WORKSPACE/build/carta_backend
       shell: bash
 
     - name: Start the carta-backend
       run: |
         SRC_DIR=$GITHUB_WORKSPACE/source
         BUILD_DIR=$GITHUB_WORKSPACE/build
+        LOG_FILE="/tmp/carta_icd_macos_${{ inputs.test_stage_name }}.log"
         cd $BUILD_DIR
         ASAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan.supp \
         LSAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan-leaks.supp \
         ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
         ./carta_backend /images --top_level_folder /images \
-        --port 5555 \
-        --omp_threads=4 --debug_no_auth --no_frontend --no_database --verbosity=5 &
+        --port ${{ inputs.port }} \
+        --omp_threads=4 --debug_no_auth --no_frontend --no_database --no_log \
+        --verbosity=5 >> "$LOG_FILE" 2>&1 &
         echo "CARTA_BACKEND_PID=$!" >> $GITHUB_ENV
+        echo "CARTA_LOG_FILE=$LOG_FILE" >> $GITHUB_ENV
       shell: bash
 
     - name: ICD tests
       run: |
         ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
         cd $ICD_DIR
-        for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
-          CI=true npm test $test_file
-          sleep 3 && pgrep carta_backend
+        failed_tests=()
+        mapfile -t test_files < ICD_test_stages/${{ inputs.test_stage_name }}.tests
+        for test_file in "${test_files[@]}"; do
+          if [ -n "$test_file" ]; then
+            if ! CI=true npm test -- "$test_file"; then
+              failed_tests+=("$test_file")
+            fi
+            sleep 3 && pgrep carta_backend
+          fi
         done
+        if [ ${#failed_tests[@]} -ne 0 ]; then
+          echo "The following tests failed:"
+          printf '%s\n' "${failed_tests[@]}"
+          exit 1
+        fi
       shell: bash
 
+    - name: Upload backend log on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: carta-backend-log-macos-${{ inputs.test_stage_name }}
+        path: ${{ env.CARTA_LOG_FILE }}
+        retention-days: 14
+
     - name: Stop carta-backend
-      run: kill ${{ env.CARTA_BACKEND_PID }}
+      if: always()
+      run: |
+        if [ -n "${{ env.CARTA_BACKEND_PID }}" ]; then
+          kill ${{ env.CARTA_BACKEND_PID }} || true
+        fi
       shell: bash

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@ linked issues and companion PRs (if there are)
 **Checklist**
 
 For the pull request:
-- [ ] The Document unchange / Need update the Document
+- [ ] Documentation has been updated (or no documentation changes are needed)

--- a/.github/workflows/all_stages_icd_tests.yml
+++ b/.github/workflows/all_stages_icd_tests.yml
@@ -32,12 +32,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -113,9 +113,7 @@ jobs:
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
           cd source ; git submodule update --init
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            ls && pwd && \
             cd $BUILD_DIR && \
-            ls && pwd && \
             cmake $SRC_DIR \
               -Dtest=on \
               -DCMAKE_BUILD_TYPE=Debug \
@@ -158,12 +156,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -190,10 +188,10 @@ jobs:
 
       - name: Prepare ICD-RxJS (macOS)
         if: matrix.os == 'macos'
+        shell: bash
         run: |
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
-          cd $ICD_DIR          
-          ls && pwd
+          cd $ICD_DIR
           git submodule init && git submodule update && npm install
           cd protobuf
           ./build_proto.sh
@@ -202,6 +200,7 @@ jobs:
 
       - name: Prepare ICD-RxJS (Linux)
         if: matrix.os == 'linux'
+        shell: bash
         run: |
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
@@ -210,7 +209,6 @@ jobs:
           git submodule update --init
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
-            ls && pwd && \
             npm install && \
             cd protobuf && \
             ./build_proto.sh && \
@@ -238,12 +236,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -293,12 +291,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -348,12 +346,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -403,12 +401,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -458,12 +456,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -513,12 +511,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -568,12 +566,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -623,12 +621,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -678,12 +676,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -733,12 +731,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -788,12 +786,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -843,12 +841,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -898,12 +896,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -953,12 +951,12 @@ jobs:
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
-            port: 9001
+            port: 9002
           - os_version: ubuntu-24.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD6]
             image: /opt/apptainer/ubuntu-2404-apr2025.sif
-            port: 9002
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]

--- a/.github/workflows/all_stages_icd_tests.yml
+++ b/.github/workflows/all_stages_icd_tests.yml
@@ -172,7 +172,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: Build              
+    needs: Build
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -260,7 +260,7 @@ jobs:
         uses: ./source/.github/actions/run-macos
         with:
           test_stage_name: 'file_browser'
-      # Linux steps    
+      # Linux steps
       - name: File Browser ICD tests
         if: matrix.os == 'linux'
         uses: ./source/.github/actions/run-apptainer
@@ -307,7 +307,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [File-Browser-ICD-Tests, Prepare-ICD-RxJS]              
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Animator ICD tests
@@ -362,7 +362,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Animator-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Region-Statistics ICD tests
@@ -417,7 +417,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Region-Statistics-ICD-Tests, Prepare-ICD-RxJS]
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Region Manipulation ICD tests
@@ -472,7 +472,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Region-Manipulation-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Cube Histogram ICD tests
@@ -527,7 +527,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Cube-Histogram-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: PV Generator ICD tests
@@ -582,7 +582,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [PV-Generator-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Raster Tiles ICD tests
@@ -637,7 +637,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Raster-Tiles-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Catalog ICD tests
@@ -692,7 +692,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Catalog-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Moment ICD tests
@@ -747,7 +747,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Moment-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Match ICD tests
@@ -802,7 +802,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Match-ICD-Tests, Prepare-ICD-RxJS]              
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Close File ICD tests
@@ -857,7 +857,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Close-File-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Image Fitting ICD tests
@@ -912,7 +912,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Image-Fitting-ICD-Tests, Prepare-ICD-RxJS]          
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Vector Overlay ICD tests
@@ -967,7 +967,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: [Vector-Overlay-ICD-Tests, Prepare-ICD-RxJS]            
+    needs: [Build, Prepare-ICD-RxJS]
     steps:
       # macOS steps
       - name: Resume ICD tests
@@ -989,8 +989,8 @@ jobs:
     name: Send email on failure
     runs-on: ubuntu-latest
     needs:
-      - Build 
-      - Prepare-ICD-RxJS 
+      - Build
+      - Prepare-ICD-RxJS
       - File-Browser-ICD-Tests
       - Animator-ICD-Tests
       - Region-Statistics-ICD-Tests

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -142,9 +142,7 @@ jobs:
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
           cd source ; git submodule update --init
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            ls && pwd && \
             cd $BUILD_DIR && \
-            ls && pwd && \
             cmake $SRC_DIR \
               -Dtest=on \
               -DCMAKE_BUILD_TYPE=Debug \
@@ -219,10 +217,10 @@ jobs:
 
       - name: Prepare ICD-RxJS (macOS)
         if: matrix.os == 'macos'
+        shell: bash
         run: |
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
-          cd $ICD_DIR          
-          ls && pwd
+          cd $ICD_DIR
           git submodule init && git submodule update && npm install
           cd protobuf
           ./build_proto.sh
@@ -231,6 +229,7 @@ jobs:
 
       - name: Prepare ICD-RxJS (Linux)
         if: matrix.os == 'linux'
+        shell: bash
         run: |
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
@@ -239,7 +238,6 @@ jobs:
           git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
-            ls && pwd && \
             npm install && \
             cd protobuf && \
             ./build_proto.sh && \

--- a/.github/workflows/single_stage_icd_tests.yml
+++ b/.github/workflows/single_stage_icd_tests.yml
@@ -132,9 +132,7 @@ jobs:
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
           cd source ; git submodule update --init
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            ls && pwd && \
             cd $BUILD_DIR && \
-            ls && pwd && \
             cmake $SRC_DIR \
               -Dtest=on \
               -DCMAKE_BUILD_TYPE=Debug \
@@ -209,10 +207,10 @@ jobs:
 
       - name: Prepare ICD-RxJS (macOS)
         if: matrix.os == 'macos'
+        shell: bash
         run: |
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
-          cd $ICD_DIR          
-          ls && pwd
+          cd $ICD_DIR
           git submodule init && git submodule update && npm install
           cd protobuf
           ./build_proto.sh
@@ -221,6 +219,7 @@ jobs:
 
       - name: Prepare ICD-RxJS (Linux)
         if: matrix.os == 'linux'
+        shell: bash
         run: |
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
@@ -229,7 +228,6 @@ jobs:
           git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
-            ls && pwd && \
             npm install && \
             cd protobuf && \
             ./build_proto.sh && \


### PR DESCRIPTION
**Description**

- Run all 14 test stages in parallel: Changed all_stages_icd_tests.yml from a sequential chain (each stage waiting for the previous one) to parallel
  execution — all test jobs now depend only on [Build, Prepare-ICD-RxJS]
 - Improve composite actions: Enhanced run-macos and run-apptainer actions with better error handling, backend log capture, and artifact uploads on
  failure
 - Fix port assignments: Corrected Linux runner ports (ubuntu-22.04: 9001→9002, ubuntu-24.04: 9002→9006) to match their ICD runner labels across all
  workflow files
 - Clean up workflows: Removed debug ls && pwd statements, added missing shell: bash declarations, and fixed typo ("Platfrom"→"Platform")
 - Improve macOS composite action: Added configurable port input, redirect backend output to log file, collect failed tests and report all at the end,
  use if: always() for backend cleanup
 - Upload backend logs on failure: Both run-macos and run-apptainer actions now upload carta_backend logs as artifacts (14-day retention) when tests
  fail
 - Update PR template: Improved checklist wording for clarity

**Checklist**

For the pull request:
- [x] The Document unchange ~/ Need update the Document~
