### PR TITLE
Update headerEntries length assertion in tests

### DIFF
--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -221,9 +221,9 @@ describe('MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
                 });
             });
 
-            test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 73`, () => {
+            test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 75`, () => {
                 momentResponse.openFileAcks.map((ack, index) => {
-                    expect(ack.fileInfoExtended.headerEntries.length).toEqual(73);
+                    expect(ack.fileInfoExtended.headerEntries.length).toEqual(75);
                 });
             });
 


### PR DESCRIPTION
Update openFileAcks[].fileInfoExtended.headerEntries.length = 75 after the modifications of carta-backend/‎src/Util/Casacore.cc

# Commit 5307450
https://github.com/CARTAvis/carta-backend/commit/5307450dd9584df5c587c636cb91115626d2f9a6

**Description**

linked issues and companion PRs (if there are)

**Checklist**

For the pull request:
- [ ] Documentation has been updated (or no documentation changes are needed)
