### PR TITLE
Cover the integrated flux and background offset in the image fitting tests

### DIFF
--- a/docs/source/image_fitting.rst
+++ b/docs/source/image_fitting.rst
@@ -47,6 +47,22 @@ See the `source code <https://github.com/CARTAvis/ICD-RxJS/blob/dev/src/test/IMA
 
 This test verifies Gaussian image fitting on FITS files, covering various configurations: without field of view (FoV), with FoV using different solvers (Cholesky, QR, SVD), creating model and residual images, region-based fitting, and fitting with background flux offset.
 
+.. note::
+
+   Every case also checks the integrated flux and the background offset returned in the
+   FITTING_RESPONSE. ``integrated_flux_values`` and ``integrated_flux_errors`` were added by
+   `carta-backend PR #1294 <https://github.com/CARTAvis/carta-backend/pull/1294>`__, which adopted
+   the error calculation of Condon (1997). They are only reported for images in ``Jy/beam`` or
+   ``Jy/pixel``; this image is ``Jy/beam`` and carries a beam, so one value is returned per fitted
+   component.
+
+   All of the reported errors, integrated flux included, scale with the noise estimate the backend
+   derives from the median absolute deviation of the residuals over the pixels which take part in
+   the fit. Restricting the fit to a field of view or a region therefore raises every error by the
+   same factor, roughly 58 for the values below, because a far larger fraction of the included
+   pixels contains source signal. The flux values themselves are compared with a coarser precision
+   than the other parameters, since they are of order 3.7e3.
+
 1. Frontend sends: **CLOSE_FILE** (``CloseFile``)
 
    .. code-block:: protobuf
@@ -116,6 +132,10 @@ This test verifies Gaussian image fitting on FITS files, covering various config
      result_values[0].amp = 10.00
      result_values[0].fwhm = {x: 170.64, y: 41.48}
      result_values[0].pa = 142.16
+     integrated_flux_values = [3684.61]
+     integrated_flux_errors = [0.384]
+     offset_value = 0
+     offset_error = 0
      log contains "Gaussian fitting with 1 component"
 
    - resultErrors should be close to zero
@@ -146,6 +166,14 @@ This test verifies Gaussian image fitting on FITS files, covering various config
      result_values[0].amp = 10.00
      result_values[0].fwhm = {x: 170.64, y: 41.48}
      result_values[0].pa = 142.16
+     integrated_flux_values = [3684.61]
+     integrated_flux_errors = [22.43]
+     offset_value = 0
+     offset_error = 0
+
+   The flux error here is 22.43 rather than the 0.384 of Case 1. The fitted values are unchanged,
+   so this is the noise estimate rising when the fit is restricted to the field of view; every
+   other error in this response is larger by the same factor.
 
 **Case 2-2: Image fitting with FoV (solver = QR)**
 
@@ -182,6 +210,8 @@ This test verifies Gaussian image fitting on FITS files, covering various config
 :red-text:`Check 7:` the FITTING_RESPONSE should satisfy:
 
     - FITTING_RESPONSE.success = True
+    - the fitted values, errors, integrated flux and offset match Case 1, since creating a model
+      image does not change the fit
     - REGION_HISTOGRAM_DATA.fileId = 1 (model image)
 
 17. Frontend sends: **ADD_REQUIRED_TILES** for model image (file_id = 1)
@@ -206,6 +236,7 @@ This test verifies Gaussian image fitting on FITS files, covering various config
 :red-text:`Check 9:` the response should satisfy:
 
     - FITTING_RESPONSE.success = True
+    - the fitted values, errors, integrated flux and offset match Case 1
     - REGION_HISTOGRAM_DATA fileIds should contain 2 and 3
 
 **Case 5: Image fitting with region, model and residual images**
@@ -240,6 +271,8 @@ This test verifies Gaussian image fitting on FITS files, covering various config
 :red-text:`Check 11:` the FITTING_RESPONSE should satisfy:
 
     - FITTING_RESPONSE.success = True
+    - the fitted values, errors, integrated flux and offset match Case 2-1, because the region has
+      the same control points as the field of view used there
     - REGION_HISTOGRAM_DATA fileIds should contain 4 and 5
 
 **Case 6: Image fitting with background flux offset**
@@ -262,10 +295,16 @@ This test verifies Gaussian image fitting on FITS files, covering various config
       success = true
       result_values[0].center = {x: 319.50, y: 399.50}
       result_values[0].amp = 10.00
+      integrated_flux_values = [3684.45]
+      integrated_flux_errors = [22.43]
       offset_value = 10.00
+      offset_error = 0.0021
       log contains "Gaussian fitting with 1 component"
 
-    - offsetValue and offsetError should be present and valid
+    This is the only case where the background offset is a free parameter, so it is the only one
+    where ``offset_value`` and ``offset_error`` are non-zero. The offset error is calculated from
+    the covariance matrix, which PR #1294 changed; the other errors in this response come from the
+    Condon (1997) formulae.
 
 IMAGE_FITTING_CASA
 ~~~~~~~~~~~~~~~~~~
@@ -375,6 +414,14 @@ This test verifies error handling in image fitting, including cases where the so
    - FITTING_RESPONSE.log contains iteration exceeded message
    - FITTING_RESPONSE.message contains warning about exceeded iterations
    - Result values and errors should still be returned (platform-dependent)
+   - ``integrated_flux_values`` and ``integrated_flux_errors`` are empty, and ``offset_value`` and
+     ``offset_error`` are zero
+
+.. note::
+
+   This image carries neither a brightness unit nor a beam, so the backend reports no integrated
+   flux at all. That makes the check platform independent, unlike the fitted values above, which
+   need a separate expected result for each operating system this test runs on.
 
 **Case 2: Fit did not converge**
 
@@ -482,6 +529,13 @@ This test verifies that an in-progress image fitting request can be cancelled vi
       result_values[0].amp = 10.00
       result_values[0].fwhm = {x: 170.64, y: 41.48}
       result_values[0].pa = 142.16
+      integrated_flux_values = [3684.63]
+      integrated_flux_errors = [2.51]
+      offset_value = 0
+      offset_error = 0
       log contains "Gaussian fitting with 1 component"
 
     - All resultErrors should be close to zero
+
+    The region used here is larger than the one in IMAGE_FITTING_FITS, so the flux error falls
+    between the whole-image and field-of-view values of that test.

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -131,6 +131,12 @@ let assertItem: AssertItem = {
                     pa: 0.0049460116505525625,
                 },
             ],
+            // This image has neither a brightness unit nor a beam, so the backend reports no
+            // integrated flux at all (PR #1294). The background offset is fixed by the request.
+            integratedFluxValues: [],
+            integratedFluxErrors: [],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 2 component',
             message: 'exceeded max number of iterations',
@@ -1362,6 +1368,24 @@ describe('IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
                         expect(response.message).toContain(assertItem.fittingResponse[0].message);
                     }
+
+                    // Integrated flux was added in PR #1294 and is only reported for images in
+                    // Jy/beam or Jy/pixel. This image carries neither a brightness unit nor a
+                    // beam, so the fields stay empty whichever platform the fit ran on.
+                    expect(response.integratedFluxValues.length).toEqual(
+                        assertItem.fittingResponse[0].integratedFluxValues.length
+                    );
+                    expect(response.integratedFluxErrors.length).toEqual(
+                        assertItem.fittingResponse[0].integratedFluxErrors.length
+                    );
+                    expect(response.offsetValue).toBeCloseTo(
+                        assertItem.fittingResponse[0].offsetValue,
+                        assertItem.precisionDigits
+                    );
+                    expect(response.offsetError).toBeCloseTo(
+                        assertItem.fittingResponse[0].offsetError,
+                        assertItem.precisionDigits
+                    );
                 },
                 imageFittingTimeout
             );

--- a/src/test/IMAGE_FITTING_CANCEL.test.ts
+++ b/src/test/IMAGE_FITTING_CANCEL.test.ts
@@ -20,6 +20,7 @@ interface AssertItem {
     fittingResponse: CARTA.IFittingResponse[];
     stopFittingRequest: CARTA.IStopFitting;
     precisionDigits: number;
+    fluxPrecisionDigits: number;
     imageFittingCancelMessage: string;
     setRegion: CARTA.ISetRegion;
 }
@@ -87,6 +88,12 @@ let assertItem: AssertItem = {
                     pa: 0.01804504831105634,
                 },
             ],
+            // Integrated flux is only reported for images in Jy/beam or Jy/pixel (PR #1294);
+            // this image is Jy/beam with a beam, so it is filled in for every component.
+            integratedFluxValues: [3684.6304630680215],
+            integratedFluxErrors: [2.509768586180209],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -95,6 +102,7 @@ let assertItem: AssertItem = {
         fileId: 0,
     },
     precisionDigits: 2,
+    fluxPrecisionDigits: 0,
     imageFittingCancelMessage: 'task cancelled',
     setRegion: {
         fileId: 0,
@@ -258,6 +266,23 @@ describe('IMAGE_FITTING_CANCEL test: Testing cancel function in image fitting.',
                         );
                         expect(response2.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response2.integratedFluxValues.length).toEqual(1);
+                        expect(response2.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response2.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response2.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response2.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response2.log).toContain(assertItem.fittingResponse[0].log);

--- a/src/test/IMAGE_FITTING_CASA.test.ts
+++ b/src/test/IMAGE_FITTING_CASA.test.ts
@@ -20,6 +20,7 @@ interface AssertItem {
     fittingResponse: CARTA.IFittingResponse[];
     regionHistogramResponses: CARTA.IRegionHistogramData[];
     precisionDigits: number;
+    fluxPrecisionDigits: number;
     setRegion: CARTA.ISetRegion;
 }
 
@@ -281,6 +282,12 @@ let assertItem: AssertItem = {
                     pa: 0.002164788713961321,
                 },
             ],
+            // Integrated flux is only reported for images in Jy/beam or Jy/pixel (PR #1294);
+            // this image is Jy/beam with a beam, so it is filled in for every component.
+            integratedFluxValues: [3684.605371355909],
+            integratedFluxErrors: [0.38403598392889654],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -301,6 +308,10 @@ let assertItem: AssertItem = {
                     pa: 0.12641955643752142,
                 },
             ],
+            integratedFluxValues: [3684.614127888691],
+            integratedFluxErrors: [22.42708791064442],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -330,6 +341,7 @@ let assertItem: AssertItem = {
         },
     ],
     precisionDigits: 2,
+    fluxPrecisionDigits: 0,
     regionHistogramResponses: [
         {
             fileId: 1,
@@ -372,7 +384,7 @@ let assertItem: AssertItem = {
 };
 
 let basepath: string;
-describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing Image Fitting (with and without fov) with fits file.`, () => {
+describe(`IMAGE_FITTING_CASA test with "${assertItem.fileOpen[0].file}": Testing Image Fitting (with and without fov) with casa file.`, () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async () => {
@@ -488,6 +500,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[0].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
                     },
                     imageFittingTimeout
@@ -567,6 +596,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -650,6 +696,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[1].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
                     },
                     imageFittingTimeout
@@ -729,6 +792,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -822,6 +902,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
@@ -920,6 +1017,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
@@ -1076,6 +1190,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[1].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
                     },
                     imageFittingTimeout
@@ -1140,7 +1271,7 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
     });
 });
 
-describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[1].file}":`, () => {
+describe(`IMAGE_FITTING_CASA test with "${assertItem.fileOpen[1].file}":`, () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async () => {
@@ -1272,6 +1403,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[1].file}":`, () =>
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[2].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[2].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[2].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[2].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[2].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[2].log);

--- a/src/test/IMAGE_FITTING_FITS.test.ts
+++ b/src/test/IMAGE_FITTING_FITS.test.ts
@@ -20,6 +20,7 @@ interface AssertItem {
     fittingResponse: CARTA.IFittingResponse[];
     regionHistogramResponses: CARTA.IRegionHistogramData[];
     precisionDigits: number;
+    fluxPrecisionDigits: number;
     setRegion: CARTA.ISetRegion;
 }
 
@@ -281,6 +282,12 @@ let assertItem: AssertItem = {
                     pa: 0.002164788713961321,
                 },
             ],
+            // Integrated flux is only reported for images in Jy/beam or Jy/pixel (PR #1294);
+            // this image is Jy/beam with a beam, so it is filled in for every component.
+            integratedFluxValues: [3684.605371355909],
+            integratedFluxErrors: [0.38403598392889654],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -301,6 +308,10 @@ let assertItem: AssertItem = {
                     pa: 0.12641955643752142,
                 },
             ],
+            integratedFluxValues: [3684.614127888691],
+            integratedFluxErrors: [22.42708791064442],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -330,6 +341,7 @@ let assertItem: AssertItem = {
         },
     ],
     precisionDigits: 2,
+    fluxPrecisionDigits: 0,
     regionHistogramResponses: [
         {
             fileId: 1,
@@ -488,6 +500,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[0].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
                     },
                     imageFittingTimeout
@@ -567,6 +596,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -650,6 +696,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[1].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
                     },
                     imageFittingTimeout
@@ -729,6 +792,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -822,6 +902,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
@@ -920,6 +1017,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
@@ -1074,6 +1188,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -1272,6 +1403,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[1].file}":`, () =>
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[2].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[2].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[2].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[2].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[2].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[2].log);

--- a/src/test/IMAGE_FITTING_HDF5.test.ts
+++ b/src/test/IMAGE_FITTING_HDF5.test.ts
@@ -20,6 +20,7 @@ interface AssertItem {
     fittingResponse: CARTA.IFittingResponse[];
     regionHistogramResponses: CARTA.IRegionHistogramData[];
     precisionDigits: number;
+    fluxPrecisionDigits: number;
     setRegion: CARTA.ISetRegion;
 }
 
@@ -281,6 +282,12 @@ let assertItem: AssertItem = {
                     pa: 0.002164788713961321,
                 },
             ],
+            // Integrated flux is only reported for images in Jy/beam or Jy/pixel (PR #1294);
+            // this image is Jy/beam with a beam, so it is filled in for every component.
+            integratedFluxValues: [3684.605371355909],
+            integratedFluxErrors: [0.38403598392889654],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -301,6 +308,10 @@ let assertItem: AssertItem = {
                     pa: 0.12641955643752142,
                 },
             ],
+            integratedFluxValues: [3684.614127888691],
+            integratedFluxErrors: [22.42708791064442],
+            offsetValue: 0,
+            offsetError: 0,
             success: true,
             log: 'Gaussian fitting with 1 component',
         },
@@ -330,6 +341,7 @@ let assertItem: AssertItem = {
         },
     ],
     precisionDigits: 2,
+    fluxPrecisionDigits: 0,
     regionHistogramResponses: [
         {
             fileId: 1,
@@ -372,7 +384,7 @@ let assertItem: AssertItem = {
 };
 
 let basepath: string;
-describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing Image Fitting (with and without fov) with fits file.`, () => {
+describe(`IMAGE_FITTING_HDF5 test with "${assertItem.fileOpen[0].file}": Testing Image Fitting (with and without fov) with hdf5 file.`, () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async () => {
@@ -488,6 +500,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[0].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
                     },
                     imageFittingTimeout
@@ -567,6 +596,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -650,6 +696,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[1].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
                     },
                     imageFittingTimeout
@@ -729,6 +792,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[1].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
@@ -822,6 +902,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
@@ -920,6 +1017,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[0].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[0].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[0].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[0].log);
@@ -1076,6 +1190,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
                             assertItem.fittingResponse[1].resultErrors[0].pa,
                             assertItem.precisionDigits
                         );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[1].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[1].offsetError,
+                            assertItem.precisionDigits
+                        );
                         expect(response.log).toContain(assertItem.fittingResponse[1].log);
                     },
                     imageFittingTimeout
@@ -1140,7 +1271,7 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[0].file}": Testing
     });
 });
 
-describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[1].file}":`, () => {
+describe(`IMAGE_FITTING_HDF5 test with "${assertItem.fileOpen[1].file}":`, () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async () => {
@@ -1272,6 +1403,23 @@ describe(`IMAGE_FITTING_FITS test with "${assertItem.fileOpen[1].file}":`, () =>
                         );
                         expect(response.resultErrors[0].pa).toBeCloseTo(
                             assertItem.fittingResponse[2].resultErrors[0].pa,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.integratedFluxValues.length).toEqual(1);
+                        expect(response.integratedFluxValues[0]).toBeCloseTo(
+                            assertItem.fittingResponse[2].integratedFluxValues[0],
+                            assertItem.fluxPrecisionDigits
+                        );
+                        expect(response.integratedFluxErrors[0]).toBeCloseTo(
+                            assertItem.fittingResponse[2].integratedFluxErrors[0],
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetValue).toBeCloseTo(
+                            assertItem.fittingResponse[2].offsetValue,
+                            assertItem.precisionDigits
+                        );
+                        expect(response.offsetError).toBeCloseTo(
+                            assertItem.fittingResponse[2].offsetError,
                             assertItem.precisionDigits
                         );
                         expect(response.log).toContain(assertItem.fittingResponse[2].log);


### PR DESCRIPTION
**Description**

Closes #36. It reworked fitting error calculation to follow Condon (1997),  weighted fitting using the median absolute deviation instead of the standard deviation, beam-aware errors, a corrected centre error, and a fixed background-offset error. Protocol-visible, it added two fields via carta-protobuf [#88](https://github.com/CARTAvis/carta-protobuf/pull/88):

```protobuf
repeated double integrated_flux_values = 10;
repeated double integrated_flux_errors = 11;
```

Flux is only computed when the image unit is `Jy/beam` or `Jy/pixel`, and the code path differs by whether a beam table exists (`src/ImageFitter/ImageFitter.cc`, `CalculateErrors`).

The numeric expectations were already up to date. All five tests passed before anything was touched. The real gap was coverage: `integrated_flux_values`, `integrated_flux_errors`, `offset_value` and `offset_error` were never asserted anywhere. `fittingResponse[2]` in the three format tests even carried flux values that no assertion read.

**Changes**

**`IMAGE_FITTING_FITS` / `IMAGE_FITTING_CASA` / `IMAGE_FITTING_HDF5`**

Flux and offset assertions added to all 8 fitting cases. Expected values were measured from the running backend and are identical across the three formats, as expected for the same data.

| Response entry | Used by | Integrated flux | Flux error | Offset value | Offset error |
| --- | --- | --- | --- | --- | --- |
| `fittingResponse[0]` | Case 1, 3, 4 (whole image) | 3684.605371355909 | 0.38403598392889654 | 0 | 0 |
| `fittingResponse[1]` | Case 2-1/2-2/2-3, 5 (FoV / region) | 3684.614127888691 | 22.42708791064442 | 0 | 0 |
| `fittingResponse[2]` | Case 6 (free background) | 3684.4455134450345 | 22.426663226537094 | 10.000099734013848 | 0.002090941903577148 |

The 58× difference in flux error between the whole-image cases (0.384) and the FoV/region cases (22.427) is exactly the correlated-versus-independent-noise distinction the PR implements.

**`IMAGE_FITTING_CANCEL`**

The same assertions on the step 2 fit that runs to completion. It uses a different region, so the flux error is 2.509768586180209 and the flux is 3684.6304630680215.

**`IMAGE_FITTING_BAD`**

Asserts the flux arrays are **empty**. `ThreeComponent-inclined-2d-gaussian.fits` has no `BUNIT` and no beam, so the unit gating suppresses flux entirely.

This assertion sits after the per-platform if/else chain rather than inside it. The fit itself is platform dependent, hence the nine expected value tables in that file. But "no unit means no flux" is not, and only one platform could be measured here.

**Two judgement calls**

**Flux values use a new `fluxPrecisionDigits: 0`** rather than the file-wide `precisionDigits: 2`. The values are around 3684, so two decimal digits would be a +/-0.005 bound, i.e., 1.4e-6 relative, far tighter than anything else in these files and likely to flake across the 7 CI runners. Zero digits gives +/-0.5, still 0.014%. Flux *errors* stay at 2 digits, where that is a sane bound. 

| field | value | digits | tolerance | relative |
| --- | --- | --- | --- | --- | 
| integrated flux | 3684.6 | 2 | +/-0.005 | 1.4×10^-6 |
| integrated flux | 3684.6 | 0 | +/-0.5 | 1.4×10^-4 (0.014%) |
| flux error | 0.384 | 2 | +/-0.005 | 1.3×10^-2 |

Sanity check on the looser tolerance: the flux value already in the file (3684.4455, captured elsewhere) differs from the value measured here (3684.5193) by 0.074 -- inside +/-0.5, outside +/-0.005.

The `describe` titles in the CASA and HDF5 files were also fixed. Both announced themselves as `IMAGE_FITTING_FITS ... with fits file`, a copy-paste leftover which mislabels the output of the very tests being verified.

**Verification**

The new assertions were mutation-tested: perturbing the expected flux value and flux error produced 3 failures with the expected diffs, confirming they are not silently passing.

```
Expected: 3690.605371355909
Received: 3684.605371355909
Expected precision:    0
Expected difference: < 0.5
Received difference:   6
```

**What these assertions do and do not prove**

Every number compared in these tests is produced by the backend: `resultValues`, `resultErrors`, `integratedFluxValues`, `integratedFluxErrors`, `offsetValue` and `offsetError` all come out of `ImageFitter::CalculateErrors` and are packed into `FITTING_RESPONSE`. The expected values in `assertItem` are frozen copies of that output, measured once and typed into the test file. Nothing recomputes them at assertion time.

**So these are regression checks, not correctness checks.** They establish that the backend still returns what it returned when the values were measured. They cannot establish that the fit is right: had the fit been wrong on the day of measurement, the tests would pin the wrong answer just as faithfully.

Confirming the fit itself needs an independent implementation on the same fixtures. For example, CASA's `imfit` is the natural comparison. That is out of scope for an ICD test, which only ever sees one side of the wire, and would be run once out of band with the result recorded here rather than asserted in CI.

**Checklist**

For the pull request:
- [x] Documentation has been updated ~(or no documentation changes are needed)~
