### PR TITLE
Update the animator contour match test for matched image tiles

### DIFF
--- a/docs/source/animator.rst
+++ b/docs/source/animator.rst
@@ -418,6 +418,24 @@ ANIMATOR_CONTOUR_MATCH
 
 See the `source code <https://github.com/CARTAvis/ICD-RxJS/blob/dev/src/test/ANIMATOR_CONTOUR_MATCH.test.ts>`__.
 
+This test verifies that a spectrally matched image is animated alongside the reference image: it
+steps through its own matched channels, returns contours and histograms at every step, and is tiled
+only while the frontend is actually rendering it.
+
+The tiles of a matched image are controlled entirely by **ADD_REQUIRED_TILES** sent *during* the
+animation. Outside an animation that message returns tile data immediately and does not become an
+animation setting, so a matched image opened before **START_ANIMATION** is not tiled until the
+frontend sends a tile request for it while the animation runs. Sending one with an empty tile list —
+which is what the frontend does when a matched image is no longer visible — stops its tiles again
+without stopping its channel updates.
+
+.. note::
+
+   The backend runs at most one animation frame ahead of the last flow-control acknowledgement, and
+   a message sent mid-frame takes effect a frame or two later. Each phase below is therefore checked
+   over the last three channels before the next client message, leaving the three channels after each
+   message unchecked.
+
 1. Frontend sends: **OPEN_FILE** (``OpenFile``) for two files
 
    File 1:
@@ -442,11 +460,11 @@ See the `source code <https://github.com/CARTAvis/ICD-RxJS/blob/dev/src/test/ANI
 
 2. Backend returns: **OPEN_FILE_ACK** (``OpenFileAck``) for each file
 
-3. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``)
+3. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for each file
 
    .. code-block:: protobuf
 
-     file_id = 0
+     file_id = 0                 // and file_id = 1
      compression_quality = 11
      compression_type = ZFP
      tiles = [0]
@@ -496,26 +514,91 @@ See the `source code <https://github.com/CARTAvis/ICD-RxJS/blob/dev/src/test/ANI
      frame_rate = 5
      matched_frames = {1: {frame_numbers: [0, 1, 2, ..., 24]}}
 
-6. Backend returns: **START_ANIMATION_ACK** (``StartAnimationAck``)
+6. Backend returns: **START_ANIMATION_ACK** (``StartAnimationAck``), then a
+   **RASTER_TILE_DATA** stream, **CONTOUR_IMAGE_DATA** and **REGION_HISTOGRAM_DATA** per channel.
+   The frontend acknowledges each channel with **ANIMATION_FLOW_CONTROL** (``AnimationFlowControl``)
+   as soon as the reference image tile arrives.
 
-:red-text:`Check 1:` the backend messages should satisfy:
+:red-text:`Check 1:` the animation of the reference image should satisfy:
 
    - START_ANIMATION_ACK.success = True
 
-   - For each animated channel: ContourImageData should arrive for both file_id = 0 and file_id = 1
+   - RASTER_TILE_DATA.channel of file_id = 0 is in ascending order from start_frame
 
-   - All ContourImageData.reference_file_id = 1
+:red-text:`Check 2:` channels 1 to 3, before any tile request for the matched image, should satisfy:
 
-   - Total ContourImageData count = stop_channel * num_levels * num_files
+   - RASTER_TILE_DATA arrives for file_id = 0 only
 
-   - Received image channels should be in ascending order
+   - No RASTER_TILE_SYNC arrives for file_id = 1
 
-7. Frontend sends: **STOP_ANIMATION** (``StopAnimation``)
+**The matched image becomes visible**
+
+7. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image, while the
+   animation is running
 
    .. code-block:: protobuf
 
-     file_id = 0
-     end_frame = {channel: 10, stokes: 0}
+     file_id = 1
+     compression_type = ZFP
+     compression_quality = 9
+     tiles = [0]
+
+:red-text:`Check 3:` channels 7 to 9 should satisfy, for both file_id = 0 and file_id = 1:
+
+   - one RASTER_TILE_DATA at that channel, with stokes = 0
+
+   - two RASTER_TILE_SYNC at that channel, one of them with end_sync = True, both with tile_count = 1
+
+**The matched image is no longer visible**
+
+8. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image with an empty
+   tile list
+
+   .. code-block:: protobuf
+
+     file_id = 1
+     compression_type = ZFP
+     compression_quality = 9
+     tiles = []
+
+:red-text:`Check 4:` channels 13 to 15 should satisfy:
+
+   - RASTER_TILE_DATA arrives for file_id = 0 only
+
+   - No RASTER_TILE_SYNC arrives for file_id = 1
+
+**The matched image is visible again**
+
+9. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image, as in step 7
+
+:red-text:`Check 5:` channels 19 to 21 should satisfy, for both file_id = 0 and file_id = 1:
+
+   - one RASTER_TILE_DATA and two RASTER_TILE_SYNC at that channel
+
+:red-text:`Check 6:` every checked channel of every phase should satisfy, for both files:
+
+   - CONTOUR_IMAGE_DATA count at progress = 1 equals the number of contour levels
+
+   - All ContourImageData.reference_file_id = 1
+
+   - One REGION_HISTOGRAM_DATA per file
+
+   The matched image keeps stepping through its own channels even while it is not tiled, so an empty
+   tile list suppresses only its raster data.
+
+10. Frontend sends: **STOP_ANIMATION** (``StopAnimation``)
+
+    .. code-block:: protobuf
+
+      file_id = 0
+      end_frame = {channel: 21, stokes: 0}
+
+11. Frontend sends: **SET_IMAGE_CHANNELS** (``SetImageChannels``) for each file at channel 0,
+    requesting one tile
+
+:red-text:`Check 7:` each file should satisfy:
+
+   - one RASTER_TILE_DATA with the matching file_id and channel = 0
 
 ANIMATOR_PLAYBACK
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/animator.rst
+++ b/docs/source/animator.rst
@@ -433,8 +433,13 @@ without stopping its channel updates.
 
    The backend runs at most one animation frame ahead of the last flow-control acknowledgement, and
    a message sent mid-frame takes effect a frame or two later. Each phase below is therefore checked
-   over the last three channels before the next client message, leaving the three channels after each
-   message unchecked.
+   over the three channels before the next client message, leaving the channels around each message
+   unchecked.
+
+   The channel on which a message is sent is itself unchecked. Within one frame the backend serves
+   the reference image and then each matched image, and the frontend sends the message as soon as the
+   reference image tile arrives, so the message can still take effect on the matched image of that
+   same frame. The channel before it is the last one whose matched image has already been served.
 
 1. Frontend sends: **OPEN_FILE** (``OpenFile``) for two files
 
@@ -534,7 +539,7 @@ without stopping its channel updates.
 **The matched image becomes visible**
 
 7. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image, while the
-   animation is running
+   animation is running, on channel 4
 
    .. code-block:: protobuf
 
@@ -552,7 +557,7 @@ without stopping its channel updates.
 **The matched image is no longer visible**
 
 8. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image with an empty
-   tile list
+   tile list, on channel 10
 
    .. code-block:: protobuf
 
@@ -569,7 +574,8 @@ without stopping its channel updates.
 
 **The matched image is visible again**
 
-9. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image, as in step 7
+9. Frontend sends: **ADD_REQUIRED_TILES** (``AddRequiredTiles``) for the matched image, as in step 7,
+   on channel 16
 
 :red-text:`Check 5:` channels 19 to 21 should satisfy, for both file_id = 0 and file_id = 1:
 
@@ -591,7 +597,7 @@ without stopping its channel updates.
     .. code-block:: protobuf
 
       file_id = 0
-      end_frame = {channel: 21, stokes: 0}
+      end_frame = {channel: 22, stokes: 0}
 
 11. Frontend sends: **SET_IMAGE_CHANNELS** (``SetImageChannels``) for each file at channel 0,
     requesting one tile

--- a/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
+++ b/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
@@ -212,6 +212,16 @@ function collectAnimation(activeFileId: number) {
     let lastActiveChannel = -1;
     let waiters: { channel: number; resolve: () => void }[] = [];
 
+    // Resolves once the active file has delivered the tile of the given channel.
+    const reached = (channel: number) =>
+        new Promise<void>((resolve) => {
+            if (lastActiveChannel >= channel) {
+                resolve();
+            } else {
+                waiters.push({ channel, resolve });
+            }
+        });
+
     const settle = () => {
         waiters = waiters.filter((waiter) => {
             if (lastActiveChannel >= waiter.channel) {
@@ -241,19 +251,10 @@ function collectAnimation(activeFileId: number) {
         msgController.histogramStream.subscribe((data) => record.histogram.push(data)),
     ];
 
-    return {
-        record,
-        // Resolves once the active file has delivered the tile of the given channel.
-        reached: (channel: number) =>
-            new Promise<void>((resolve) => {
-                if (lastActiveChannel >= channel) {
-                    resolve();
-                } else {
-                    waiters.push({ channel, resolve });
-                }
-            }),
-        stop: () => subscriptions.forEach((subscription) => subscription.unsubscribe()),
-    };
+    // Ends the collection once the playback is over.
+    const stop = () => subscriptions.forEach((subscription) => subscription.unsubscribe());
+
+    return { record, reached, stop };
 }
 
 let basepath: string;

--- a/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
+++ b/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
@@ -139,7 +139,7 @@ let assertItem: AssertItem = {
     },
     stopAnimation: {
         fileId: 0,
-        endFrame: { channel: 21, stokes: 0 },
+        endFrame: { channel: 22, stokes: 0 },
     },
     setImageChannel: [
         {
@@ -167,24 +167,29 @@ let assertItem: AssertItem = {
     ],
     // The active file's channel at which each client message is sent.
     milestone: {
-        requestMatchedTiles: 3,
-        hideMatchedImage: 9,
-        restoreMatchedImage: 15,
-        stop: 21,
+        requestMatchedTiles: 4,
+        hideMatchedImage: 10,
+        restoreMatchedImage: 16,
+        stop: 22,
     },
 };
 
 /**
  * The backend runs at most one animation frame ahead of the last flow-control ack, and a client
  * message queued mid-frame lands a frame or two later. Each phase is therefore asserted over the
- * last three channels before the next milestone, which leaves the three channels right after a
- * milestone as an unasserted settling band.
+ * three channels before its milestone, which leaves the channels around a milestone as an
+ * unasserted settling band.
+ *
+ * The milestone channel itself is excluded: within a frame the backend serves the reference image
+ * and then each matched image, and the milestone message is sent on the reference image's tile, so
+ * it can still land before the matched image of that same frame is served. Channel milestone - 1 is
+ * the last one whose matched image is already out.
  */
 const WINDOW_CHANNELS = 3;
 
 function assertedChannels(milestone: number): number[] {
     let channels: number[] = [];
-    for (let channel = milestone - WINDOW_CHANNELS + 1; channel <= milestone; channel++) {
+    for (let channel = milestone - WINDOW_CHANNELS; channel <= milestone - 1; channel++) {
         channels.push(channel);
     }
     return channels;
@@ -336,9 +341,9 @@ describe('ANIMATOR_CONTOUR_MATCH: Testing animation playback of a spectrally mat
                     await collector.reached(assertItem.milestone.restoreMatchedImage);
                     msgController.addRequiredTiles(assertItem.matchedTilesReq);
 
+                    // The reference image's tile of the stop channel implies every message of the
+                    // last asserted frame is already out, but leave a margin before unsubscribing.
                     await collector.reached(assertItem.milestone.stop);
-                    // The matched image is served after the reference image within a frame, so let
-                    // the rest of the last asserted frame arrive before unsubscribing.
                     await new Promise((resolve) => setTimeout(resolve, messageReturnTimeout));
                     msgController.stopAnimation(assertItem.stopAnimation);
                     collector.stop();

--- a/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
+++ b/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
@@ -1,31 +1,38 @@
 import { CARTA } from 'carta-protobuf';
-import { checkConnection, Stream } from './MyClient';
 import * as Long from 'long';
+import { Subscription } from 'rxjs';
+import { checkConnection, Stream } from './MyClient';
 import { MessageController } from './MessageController';
 import config from './config.json';
-import { take } from 'rxjs/operators';
 
 let connectTimeout = config.timeout.connection;
 let testServerUrl: string = config.serverURL0;
 let testSubdirectory: string = config.path.QA;
 let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile;
+let playAnimatorTimeout: number = config.timeout.playAnimator;
+let changeChannelTimeout: number = config.timeout.changeChannel;
+let messageReturnTimeout: number = config.timeout.messageEvent;
 
 interface AssertItem {
-    registerViewer: CARTA.IRegisterViewer;
     filelist: CARTA.IFileListRequest;
     fileOpen: CARTA.IOpenFile[];
-    addTilesReq: CARTA.IAddRequiredTiles;
+    initTilesReq: CARTA.IAddRequiredTiles[];
     setContour: CARTA.ISetContourParameters[];
     startAnimation: CARTA.IStartAnimation;
+    matchedTilesReq: CARTA.IAddRequiredTiles;
+    hiddenTilesReq: CARTA.IAddRequiredTiles;
     stopAnimation: CARTA.IStopAnimation;
     setImageChannel: CARTA.ISetImageChannels[];
+    milestone: {
+        requestMatchedTiles: number;
+        hideMatchedImage: number;
+        restoreMatchedImage: number;
+        stop: number;
+    };
 }
 
 let assertItem: AssertItem = {
-    registerViewer: {
-        sessionId: 0,
-        clientFeatureFlags: 5,
-    },
     filelist: { directory: testSubdirectory },
     fileOpen: [
         {
@@ -43,12 +50,20 @@ let assertItem: AssertItem = {
             renderMode: CARTA.RenderMode.RASTER,
         },
     ],
-    addTilesReq: {
-        fileId: 0,
-        compressionQuality: 11,
-        compressionType: CARTA.CompressionType.ZFP,
-        tiles: [0],
-    },
+    initTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+    ],
     setContour: [
         {
             fileId: 0,
@@ -106,9 +121,25 @@ let assertItem: AssertItem = {
             },
         },
     },
+    // Sent while the animation is running. This is the only way the matched image can acquire
+    // animation view settings: outside an animation ADD_REQUIRED_TILES returns tile data instead.
+    matchedTilesReq: {
+        fileId: 1,
+        tiles: [0],
+        compressionType: CARTA.CompressionType.ZFP,
+        compressionQuality: 9,
+    },
+    // What the frontend sends when a matched image scrolls out of view during animation:
+    // AppStore's view autorun pushes a view update with an empty tile list for it.
+    hiddenTilesReq: {
+        fileId: 1,
+        tiles: [],
+        compressionType: CARTA.CompressionType.ZFP,
+        compressionQuality: 9,
+    },
     stopAnimation: {
         fileId: 0,
-        endFrame: { channel: 10, stokes: 0 },
+        endFrame: { channel: 21, stokes: 0 },
     },
     setImageChannel: [
         {
@@ -127,17 +158,106 @@ let assertItem: AssertItem = {
             channel: 0,
             stokes: 0,
             requiredTiles: {
-                fileId: 0,
+                fileId: 1,
                 tiles: [0],
                 compressionType: CARTA.CompressionType.ZFP,
                 compressionQuality: 11,
             },
         },
     ],
+    // The active file's channel at which each client message is sent.
+    milestone: {
+        requestMatchedTiles: 3,
+        hideMatchedImage: 9,
+        restoreMatchedImage: 15,
+        stop: 21,
+    },
 };
 
+/**
+ * The backend runs at most one animation frame ahead of the last flow-control ack, and a client
+ * message queued mid-frame lands a frame or two later. Each phase is therefore asserted over the
+ * last three channels before the next milestone, which leaves the three channels right after a
+ * milestone as an unasserted settling band.
+ */
+const WINDOW_CHANNELS = 3;
+
+function assertedChannels(milestone: number): number[] {
+    let channels: number[] = [];
+    for (let channel = milestone - WINDOW_CHANNELS + 1; channel <= milestone; channel++) {
+        channels.push(channel);
+    }
+    return channels;
+}
+
+interface AnimationRecord {
+    sync: CARTA.RasterTileSync[];
+    tile: CARTA.RasterTileData[];
+    contour: CARTA.ContourImageData[];
+    histogram: CARTA.RegionHistogramData[];
+}
+
+/**
+ * Subscribe to every animation stream for the whole playback rather than per frame.
+ *
+ * The RxJS subjects do not buffer, so a per-frame subscribe/await loop can drop messages of the
+ * frame the backend is already working on. Subscribing once up front also removes any assumption
+ * about the order in which the active and the matched image are served within a frame.
+ *
+ * Flow control is acknowledged from the active file's tile, which is what paces the animation.
+ */
+function collectAnimation(activeFileId: number) {
+    const msgController = MessageController.Instance;
+    const record: AnimationRecord = { sync: [], tile: [], contour: [], histogram: [] };
+    let lastActiveChannel = -1;
+    let waiters: { channel: number; resolve: () => void }[] = [];
+
+    const settle = () => {
+        waiters = waiters.filter((waiter) => {
+            if (lastActiveChannel >= waiter.channel) {
+                waiter.resolve();
+                return false;
+            }
+            return true;
+        });
+    };
+
+    const subscriptions: Subscription[] = [
+        msgController.rasterSyncStream.subscribe((data) => record.sync.push(data)),
+        msgController.rasterTileStream.subscribe((data) => {
+            record.tile.push(data);
+            if (data.fileId === activeFileId) {
+                lastActiveChannel = data.channel;
+                msgController.sendAnimationFlowControl({
+                    fileId: activeFileId,
+                    animationId: 0,
+                    receivedFrame: { channel: data.channel, stokes: data.stokes },
+                    timestamp: Long.fromNumber(Date.now()),
+                });
+                settle();
+            }
+        }),
+        msgController.contourStream.subscribe((data) => record.contour.push(data)),
+        msgController.histogramStream.subscribe((data) => record.histogram.push(data)),
+    ];
+
+    return {
+        record,
+        // Resolves once the active file has delivered the tile of the given channel.
+        reached: (channel: number) =>
+            new Promise<void>((resolve) => {
+                if (lastActiveChannel >= channel) {
+                    resolve();
+                } else {
+                    waiters.push({ channel, resolve });
+                }
+            }),
+        stop: () => subscriptions.forEach((subscription) => subscription.unsubscribe()),
+    };
+}
+
 let basepath: string;
-describe('ANIMATOR_CONTOUR: Testing animation playback with contour lines', () => {
+describe('ANIMATOR_CONTOUR_MATCH: Testing animation playback of a spectrally matched image', () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async () => {
@@ -172,149 +292,195 @@ describe('ANIMATOR_CONTOUR: Testing animation playback with contour lines', () =
         });
 
         describe(`Preparation`, () => {
-            test(`Contour set`, async () => {
-                msgController.addRequiredTiles(assertItem.addTilesReq);
-                let RasterTileDataResponse = await Stream(
-                    CARTA.RasterTileData,
-                    assertItem.addTilesReq.tiles.length + 2
-                );
+            test(
+                `Render both images and set matched contours`,
+                async () => {
+                    for (let i = 0; i < assertItem.initTilesReq.length; i++) {
+                        let rasterResponse = Stream(CARTA.RasterTileData, assertItem.initTilesReq[i].tiles!.length + 2);
+                        msgController.addRequiredTiles(assertItem.initTilesReq[i]);
+                        await rasterResponse;
+                    }
 
-                msgController.setContourParameters(assertItem.setContour[0]);
-                let ContourImageDataResponse1 = await Stream(
-                    CARTA.ContourImageData,
-                    assertItem.setContour[0].levels.length
-                );
+                    for (let i = 0; i < assertItem.setContour.length; i++) {
+                        let contourResponse = Stream(CARTA.ContourImageData, assertItem.setContour[i].levels!.length);
+                        msgController.setContourParameters(assertItem.setContour[i]);
+                        await contourResponse;
+                    }
+                },
+                readFileTimeout * 2
+            );
+        });
 
-                msgController.setContourParameters(assertItem.setContour[1]);
-                let ContourImageDataResponse2 = await Stream(
-                    CARTA.ContourImageData,
-                    assertItem.setContour[1].levels.length
-                );
+        describe(`Play the animation of the reference image`, () => {
+            let record: AnimationRecord;
+
+            test(
+                `Play up to channel ${assertItem.milestone.stop}, hiding and restoring the matched image`,
+                async () => {
+                    const collector = collectAnimation(assertItem.startAnimation.fileId!);
+                    record = collector.record;
+
+                    let StartAnimationResponse = await msgController.startAnimation(assertItem.startAnimation);
+                    expect(StartAnimationResponse.success).toEqual(true);
+
+                    // The matched image has no animation view settings yet, so it is not tiled.
+                    await collector.reached(assertItem.milestone.requestMatchedTiles);
+                    msgController.addRequiredTiles(assertItem.matchedTilesReq);
+
+                    // The matched image goes out of view: an empty tile list stops its tiles.
+                    await collector.reached(assertItem.milestone.hideMatchedImage);
+                    msgController.addRequiredTiles(assertItem.hiddenTilesReq);
+
+                    // The matched image comes back into view.
+                    await collector.reached(assertItem.milestone.restoreMatchedImage);
+                    msgController.addRequiredTiles(assertItem.matchedTilesReq);
+
+                    await collector.reached(assertItem.milestone.stop);
+                    // The matched image is served after the reference image within a frame, so let
+                    // the rest of the last asserted frame arrive before unsubscribing.
+                    await new Promise((resolve) => setTimeout(resolve, messageReturnTimeout));
+                    msgController.stopAnimation(assertItem.stopAnimation);
+                    collector.stop();
+                },
+                playAnimatorTimeout
+            );
+
+            test(`START_ANIMATION_ACK.success = True and the reference channels are in sequence`, () => {
+                let channels = record.tile
+                    .filter((data) => data.fileId === assertItem.startAnimation.fileId)
+                    .map((data) => data.channel);
+                channels.map((channel, index) => {
+                    expect(channel).toEqual(assertItem.startAnimation.startFrame!.channel! + index);
+                });
+                expect(channels.length).toBeGreaterThanOrEqual(assertItem.milestone.stop);
+            });
+
+            describe(`Before ADD_REQUIRED_TILES of the matched image`, () => {
+                assertedChannels(assertItem.milestone.requestMatchedTiles).map((channel) => {
+                    test(`Channel ${channel}: only the reference image is tiled`, () => {
+                        expect(
+                            record.tile.filter((data) => data.fileId === 0 && data.channel === channel).length
+                        ).toEqual(1);
+                        expect(
+                            record.tile.filter((data) => data.fileId === 1 && data.channel === channel).length
+                        ).toEqual(0);
+                        expect(
+                            record.sync.filter((data) => data.fileId === 1 && data.channel === channel).length
+                        ).toEqual(0);
+                    });
+                });
+            });
+
+            describe(`After ADD_REQUIRED_TILES of the matched image`, () => {
+                assertedChannels(assertItem.milestone.hideMatchedImage).map((channel) => {
+                    test(`Channel ${channel}: both images are tiled`, () => {
+                        assertItem.fileOpen.map((file) => {
+                            let tiles = record.tile.filter(
+                                (data) => data.fileId === file.fileId && data.channel === channel
+                            );
+                            expect(tiles.length).toEqual(1);
+                            expect(tiles[0].stokes).toEqual(0);
+
+                            let syncs = record.sync.filter(
+                                (data) => data.fileId === file.fileId && data.channel === channel
+                            );
+                            expect(syncs.length).toEqual(2);
+                            expect(syncs.filter((data) => data.endSync).length).toEqual(1);
+                            expect(syncs.filter((data) => data.tileCount === 1).length).toEqual(2);
+                        });
+                    });
+                });
+            });
+
+            describe(`After ADD_REQUIRED_TILES of the matched image with an empty tile list`, () => {
+                assertedChannels(assertItem.milestone.restoreMatchedImage).map((channel) => {
+                    test(`Channel ${channel}: only the reference image is tiled`, () => {
+                        expect(
+                            record.tile.filter((data) => data.fileId === 0 && data.channel === channel).length
+                        ).toEqual(1);
+                        expect(
+                            record.tile.filter((data) => data.fileId === 1 && data.channel === channel).length
+                        ).toEqual(0);
+                        expect(
+                            record.sync.filter((data) => data.fileId === 1 && data.channel === channel).length
+                        ).toEqual(0);
+                    });
+                });
+            });
+
+            describe(`After the matched image is restored`, () => {
+                assertedChannels(assertItem.milestone.stop).map((channel) => {
+                    test(`Channel ${channel}: both images are tiled`, () => {
+                        assertItem.fileOpen.map((file) => {
+                            expect(
+                                record.tile.filter((data) => data.fileId === file.fileId && data.channel === channel)
+                                    .length
+                            ).toEqual(1);
+                            expect(
+                                record.sync.filter((data) => data.fileId === file.fileId && data.channel === channel)
+                                    .length
+                            ).toEqual(2);
+                        });
+                    });
+                });
+            });
+
+            describe(`Contours and histograms of the matched image`, () => {
+                // The matched image keeps stepping through its own channels even while it is not
+                // tiled, so its contours and histograms arrive in every phase.
+                let allChannels = [
+                    ...assertedChannels(assertItem.milestone.requestMatchedTiles),
+                    ...assertedChannels(assertItem.milestone.hideMatchedImage),
+                    ...assertedChannels(assertItem.milestone.restoreMatchedImage),
+                    ...assertedChannels(assertItem.milestone.stop),
+                ];
+
+                allChannels.map((channel) => {
+                    test(`Channel ${channel}: both images return contours and a histogram`, () => {
+                        assertItem.setContour.map((contour) => {
+                            let contours = record.contour.filter(
+                                (data) =>
+                                    data.fileId === contour.fileId && data.channel === channel && data.progress === 1
+                            );
+                            expect(contours.length).toEqual(contour.levels!.length);
+                            contours.map((data) => {
+                                expect(data.referenceFileId).toEqual(contour.referenceFileId);
+                            });
+
+                            expect(
+                                record.histogram.filter(
+                                    (data) => data.fileId === contour.fileId && data.channel === channel
+                                ).length
+                            ).toEqual(1);
+                        });
+                    });
+                });
             });
         });
 
-        describe(`Play some channels forwardly`, () => {
-            let regionHistogramData: CARTA.RegionHistogramData[] = [];
-            let sequence: number[] = [];
-            let contourImageData: CARTA.ContourImageData[] = [];
-            let HistogramSequence: number[] = [];
-            let ContourSequence: number[] = [];
-            test(`Assert ContourImageData.channel = RasterTileData.channel`, async () => {
-                let StartAnimationResponse = await msgController.startAnimation(assertItem.startAnimation);
-                expect(StartAnimationResponse.success).toEqual(true);
+        describe(`Set the channel of each image after STOP_ANIMATION`, () => {
+            assertItem.setImageChannel.map((setImageChannel) => {
+                let rasterTileData: CARTA.RasterTileData[];
 
-                for (let i = 0; i < assertItem.stopAnimation.endFrame.channel; i++) {
-                    msgController.addRequiredTiles(assertItem.addTilesReq);
-                    let resRegionHistogramData = msgController.histogramStream.pipe(take(2)).subscribe({
-                        next: (data) => {
-                            regionHistogramData.push(data);
-                            HistogramSequence.push(data.channel);
-                        },
-                    });
-                    let rasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
-                    let resContourImageData = msgController.contourStream.pipe(take(4)).subscribe({
-                        next: (data) => {
-                            contourImageData.push(data);
-                            ContourSequence.push(data.channel);
-                        },
-                    });
-                    let currentChannel = rasterTileDataResponse[0].channel;
-                    sequence.push(currentChannel);
-                    msgController.sendAnimationFlowControl({
-                        fileId: 0,
-                        animationId: 0,
-                        receivedFrame: {
-                            channel: currentChannel,
-                            stokes: 0,
-                        },
-                        timestamp: Long.fromNumber(Date.now()),
-                    });
-                }
-
-                // // Pick up the streaming messages
-                // // Channel 11 & 12: RasterTileData + RasterTileSync(start & end) + RegionHistogramData
-                // let RegionHistogramDataChannel11: CARTA.RegionHistogramData[] = [];
-                // msgController.histogramStream.pipe(take(1)).subscribe(data => {
-                //     RegionHistogramDataChannel11.push(data)
-                // });
-                // let ContourImageDataChannel11 = await Stream(CARTA.ContourImageData,4)
-                // console.log(ContourImageDataChannel11);
-                // let RasterTileDataChannel11 = await Stream(CARTA.RasterTileData,3);
-                // console.log(RasterTileDataChannel11);
-
-                // let RegionHistogramDataChannel12: CARTA.RegionHistogramData[] = [];
-                // msgController.histogramStream.pipe(take(1)).subscribe(data => {
-                //     RegionHistogramDataChannel12.push(data)
-                // });
-                // let ContourImageDataChannel12 = await Stream(CARTA.ContourImageData,4)
-                // console.log(ContourImageDataChannel12);
-                // let RasterTileDataChannel12 = await Stream(CARTA.RasterTileData,3);
-                // console.log(RasterTileDataChannel12)
-            });
-
-            test(`Assert the last channel = StopAnimation.endFrame`, async () => {
-                msgController.stopAnimation(assertItem.stopAnimation);
-                msgController.setChannels(assertItem.setImageChannel[0]);
-                let lastRegionHistogramData1: CARTA.RegionHistogramData[] = [];
-                msgController.histogramStream.pipe(take(1)).subscribe({
-                    next: (data) => {
-                        lastRegionHistogramData1.push(data);
+                test(
+                    `File ${setImageChannel.fileId}: SET_IMAGE_CHANNELS returns RASTER_TILE_DATA`,
+                    async () => {
+                        let rasterResponse = Stream(
+                            CARTA.RasterTileData,
+                            setImageChannel.requiredTiles!.tiles!.length + 2
+                        );
+                        msgController.setChannels(setImageChannel);
+                        rasterTileData = (await rasterResponse).filter(
+                            (data: any) => data instanceof CARTA.RasterTileData
+                        );
                     },
-                });
-                let lastContourImageData1: CARTA.ContourImageData[] = [];
-                msgController.contourStream.pipe(take(2)).subscribe({
-                    next: (data) => {
-                        lastContourImageData1.push(data);
-                    },
-                });
-
-                let lastRasterTileData1 = await Stream(CARTA.RasterTileData, 3);
-
-                msgController.setChannels(assertItem.setImageChannel[1]);
-                let lastRegionHistogramData2: CARTA.RegionHistogramData[] = [];
-                msgController.histogramStream.pipe(take(1)).subscribe({
-                    next: (data) => {
-                        lastRegionHistogramData2.push(data);
-                    },
-                });
-                let lastContourImageData2: CARTA.ContourImageData[] = [];
-                msgController.contourStream.pipe(take(2)).subscribe({
-                    next: (data) => {
-                        lastContourImageData2.push(data);
-                    },
-                });
-
-                let lastRasterTileData2 = await Stream(CARTA.RasterTileData, 3);
-            });
-
-            test(`Received image channels should be in sequence`, async () => {
-                sequence.map((id, index) => {
-                    let channelId =
-                        index +
-                        assertItem.startAnimation.startFrame.channel +
-                        assertItem.startAnimation.deltaFrame.channel;
-                    expect(id).toEqual(channelId - 1);
-                });
-            });
-
-            test(`Assert a series of ContourImageData`, async () => {
-                for (let i = 2; i <= assertItem.stopAnimation.endFrame.channel; i++) {
-                    let testSet = contourImageData.filter((data) => data.progress == 1 && data.channel == i);
-                    expect(testSet.length).toEqual(assertItem.setContour[0].levels.length * assertItem.fileOpen.length);
-                    expect(testSet.filter((data) => data.fileId == 0).length).toEqual(
-                        assertItem.setContour[0].levels.length
-                    );
-                    expect(testSet.filter((data) => data.fileId == 1).length).toEqual(
-                        assertItem.setContour[1].levels.length
-                    );
-                }
-                expect(contourImageData.length).toEqual(
-                    assertItem.stopAnimation.endFrame.channel *
-                        assertItem.setContour[0].levels.length *
-                        assertItem.fileOpen.length
+                    changeChannelTimeout
                 );
-                contourImageData.map((data) => {
-                    expect(data.referenceFileId).toEqual(1);
+
+                test(`File ${setImageChannel.fileId}: RASTER_TILE_DATA.channel = ${setImageChannel.channel}`, () => {
+                    expect(rasterTileData.length).toEqual(1);
+                    expect(rasterTileData[0].fileId).toEqual(setImageChannel.fileId);
+                    expect(rasterTileData[0].channel).toEqual(setImageChannel.channel);
                 });
             });
         });


### PR DESCRIPTION
**Description**

Closes #24. Updates `ANIMATOR_CONTOUR_MATCH` for backend PR CARTAvis/carta-backend [#1270](https://github.com/CARTAvis/carta-backend/pull/1270), which started sending raster tiles of spectrally matched images during animation.

The test previously watched only the reference image: it awaited one tile group per frame and asserted contours for both files. It passed for the wrong reason: the matched image was never tiled, because nothing in the test ever gave it animation view settings.

`Session::ExecuteAnimationFrameInner` (`Session.cc:2214-2278`) now walks every file in `matched_frames` on each animation frame, advances its `z`, and sends contours, vector field, **tile
data** and region data for each. The tile request comes from that file's stored `GetAnimationViewSettings()`.

How a matched image acquires those settings is the non-obvious part. `OnMessageTask.tcc:18` dispatches `ADD_REQUIRED_TILES` with `skip_data = AnimationRunning()`, and `OnAddRequiredTiles` stores the message as animation view settings *only* on that path:

| when | effect |
| --- | --- |
| outside an animation | returns tile data immediately, stores nothing |
| during an animation | stores the view settings, sends nothing now |
| during an animation, empty `tiles` | stores empty settings, so later frames early-return |

So a matched image opened before `START_ANIMATION` is not tiled at all until the frontend sends a tile request for it *while the animation runs*, and an empty tile list, which is what [AppStore.ts:2056-2062](https://github.com/CARTAvis/carta-frontend/blob/dev/src/stores/AppStore/AppStore.ts#L2056) pushes when a matched image is no longer visible, stops its tiles again without stopping its channel updates.

**What the test pins**

One continuous playback through four states, three channels checked in each:

1. **Channels 1-3**, before any tile request for the matched image: only the reference image is tiled, and no `RASTER_TILE_SYNC` arrives for the matched one.

2. **Channels 7-9**, after `ADD_REQUIRED_TILES` for the matched image, sent mid-animation on channel 4: both images get one `RASTER_TILE_DATA` and a complete start/end sync pair per channel.

3. **Channels 13-15**, after `ADD_REQUIRED_TILES` with an empty tile list on channel 10: only the reference image again.

4. **Channels 19-21**, after the tile request is repeated on channel 16: both images again.

Across every checked channel of every phase, both images return their contours (at `progress = 1`, with `reference_file_id = 1`) and one histogram. That is the discriminating check: the matched image keeps stepping through its own channels while it is not tiled, so an empty tile list suppresses only raster data.

**Two structural changes**

**The per-frame stream loop had to go.** `Stream(CARTA.RasterTileData, n)` takes two messages off `rasterSyncStream` and `n-2` off `rasterTileStream`, resolving on the end sync. It assumes a single sync group, and there are two per frame once the matched image is tiled. The old subscribe/await/ack loop was also problematic: the RxJS subjects do not buffer, and the backend runs a frame ahead, so messages of the frame in flight could be dropped. The test now subscribes once to all four streams for the whole playback and acknowledges flow control from the reference image's tile, which is what paces the animation.

**Tiles are asserted per `file_id`, not by arrival order.** `_matched_frames` is an `unordered_map`, so the order in which the two images are served within a frame is not part of the interface.

Phases are spaced 6 channels apart with a 3-channel window asserted. The backend runs at most one frame ahead of the last flow-control ack, and a client message queued mid-frame lands a frame or two later, so the unchecked channels around each message are a settling band worth ~600 ms.

**The channel a message is sent on is not asserted.** Within a frame, the backend serves the reference image, and then each matched image, and the test sends its message as soon as the reference image tile arrives. So the message races the remaining half of that frame and may or may not take effect on it. 

`milestone - 1` is the last channel whose matched image was already on the wire when the message went out, so the window ends there. This is race-free by construction rather than by timing margin, which matters because the two sides of that race resolve differently per platform: the first draft asserted the milestone channel itself and passed on every Linux runner while failing all three view-setting milestones on macOS.

**Changes**

| File | |
| --- | --- |
| `src/test/ANIMATOR_CONTOUR_MATCH.test.ts` | rewritten - 34 tests |
| `docs/source/animator.rst` | document the four phases as Checks 1-7 |

No stage-file change: `ICD_test_stages/animator.tests` already lists the test. Fixtures (`M17_SWex.fits`, `M17_SWex.image`) are unchanged and already in `set_QA`.

Also fixes a latent fixture bug: `setImageChannel[1]` had `fileId: 1` but `requiredTiles.fileId: 0`, so the post-animation tile request was aimed at the wrong image.

**Checklist**

For the pull request:
- [x] Documentation has been updated ~(or no documentation changes are needed)~
